### PR TITLE
fix: use authority time for launch tickets

### DIFF
--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -47,7 +47,9 @@ export async function validateInstalledClient(installation: InstalledClientConfi
   return root;
 }
 
-function sanitizedEnvironment(identity: LaunchTicketIdentity): NodeJS.ProcessEnv {
+function sanitizedEnvironment(
+  identity: Pick<LaunchTicketIdentity, "displayName" | "steamId">,
+): NodeJS.ProcessEnv {
   const environment: NodeJS.ProcessEnv = { ...process.env };
   for (const key of Object.keys(environment)) {
     const normalized = key.toLocaleUpperCase("en-US");
@@ -162,7 +164,7 @@ export class GameLauncher {
       // or a slow disk. Refresh only after that expensive work, then rewrite
       // the identity-bound local gateway/configuration before spawning H1Z1.
       try {
-        assertLaunchTicketFresh(launchIdentity.expiresAt);
+        assertLaunchTicketFresh(launchIdentity);
       } catch {
         await sessionGateway.close().catch(() => undefined);
         launchIdentity = await createLaunchTicket(
@@ -176,7 +178,7 @@ export class GameLauncher {
           sessionGateway.createSessionUrl,
           launchIdentity,
         );
-        assertLaunchTicketFresh(launchIdentity.expiresAt);
+        assertLaunchTicketFresh(launchIdentity);
       }
 
       const args = buildLaunchArguments(

--- a/electron/services/launch-ticket.ts
+++ b/electron/services/launch-ticket.ts
@@ -7,14 +7,20 @@ const STEAM_ID_PATTERN = /^\d{17}$/;
 const DECIMAL_ID_PATTERN = /^[1-9]\d{0,18}$/;
 const MAX_SIGNED_63_BIT = 9_223_372_036_854_775_807n;
 const MINIMUM_TICKET_LIFETIME_MS = 10_000;
+const MAXIMUM_SERVER_TICKET_LIFETIME_MS = 10 * 60_000;
 
 export interface LaunchTicketIdentity {
-  ticket: string;
-  expiresAt: string;
-  rotkId: string;
-  gameAccountGuid: string;
-  steamId: string;
-  displayName: string;
+  readonly ticket: string;
+  readonly issuedAt: string;
+  readonly expiresAt: string;
+  /** Monotonic receipt time; never derived from the workstation wall clock. */
+  readonly receivedAtMonotonicMs: number;
+  /** Conservative remaining lifetime at receipt, based on authority timestamps. */
+  readonly initialRemainingLifetimeMs: number;
+  readonly rotkId: string;
+  readonly gameAccountGuid: string;
+  readonly steamId: string;
+  readonly displayName: string;
 }
 
 interface TicketRequestOptions {
@@ -37,21 +43,64 @@ function validateEndpoint(value: string): URL {
 }
 
 export function assertLaunchTicketFresh(
-  expiresAt: string,
+  identity: Pick<
+    LaunchTicketIdentity,
+    "receivedAtMonotonicMs" | "initialRemainingLifetimeMs"
+  >,
   minimumLifetimeMs = MINIMUM_TICKET_LIFETIME_MS,
+  nowMonotonicMs = performance.now(),
 ): void {
-  const expiresAtMs = Date.parse(expiresAt);
-  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now() + minimumLifetimeMs) {
+  if (
+    !Number.isFinite(minimumLifetimeMs)
+    || minimumLifetimeMs < 0
+    || minimumLifetimeMs > MAXIMUM_SERVER_TICKET_LIFETIME_MS
+    || !Number.isFinite(nowMonotonicMs)
+    || !Number.isFinite(identity.receivedAtMonotonicMs)
+    || !Number.isFinite(identity.initialRemainingLifetimeMs)
+    || identity.initialRemainingLifetimeMs <= 0
+    || identity.initialRemainingLifetimeMs > MAXIMUM_SERVER_TICKET_LIFETIME_MS
+  ) {
+    throw new Error("Invalid ROTK launch ticket freshness check");
+  }
+  const elapsedSinceReceiptMs = Math.max(
+    0,
+    nowMonotonicMs - identity.receivedAtMonotonicMs,
+  );
+  if (identity.initialRemainingLifetimeMs - elapsedSinceReceiptMs <= minimumLifetimeMs) {
     throw new Error("The ROTK launch ticket expires too soon");
   }
 }
 
-function parseTicketResponse(value: unknown): LaunchTicketIdentity {
+function parseCanonicalAuthorityTimestamp(value: string): number {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return Number.NaN;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+    ? parsed
+    : Number.NaN;
+}
+
+interface TicketResponseTiming {
+  readonly requestStartedAtMonotonicMs: number;
+  readonly receivedAtMonotonicMs: number;
+}
+
+function parseTicketResponse(
+  value: unknown,
+  timing: TicketResponseTiming = {
+    requestStartedAtMonotonicMs: performance.now(),
+    receivedAtMonotonicMs: performance.now(),
+  },
+): LaunchTicketIdentity {
   if (!value || typeof value !== "object") throw new Error("Invalid response from the ROTK account service");
   const response = value as Record<string, unknown>;
+  const issuedAt = typeof response.issuedAt === "string" ? response.issuedAt : "";
   const expiresAt = typeof response.expiresAt === "string" ? response.expiresAt : "";
   const displayName = typeof response.displayName === "string" ? response.displayName.trim() : "";
   const gameAccountGuid = typeof response.gameAccountGuid === "string" ? response.gameAccountGuid : "";
+  const issuedAtMs = parseCanonicalAuthorityTimestamp(issuedAt);
+  const expiresAtMs = parseCanonicalAuthorityTimestamp(expiresAt);
+  const requestElapsedMs = timing.receivedAtMonotonicMs - timing.requestStartedAtMonotonicMs;
+  const serverTicketLifetimeMs = expiresAtMs - issuedAtMs;
   if (
     response.ok !== true
     || !isValidLaunchTicket(response.ticket)
@@ -62,20 +111,34 @@ function parseTicketResponse(value: unknown): LaunchTicketIdentity {
     || displayName.length < 1
     || displayName.length > 32
     || /[\u0000-\u001f\u007f]/u.test(displayName)
+    || !Number.isFinite(issuedAtMs)
+    || !Number.isFinite(expiresAtMs)
+    || !Number.isFinite(timing.requestStartedAtMonotonicMs)
+    || !Number.isFinite(timing.receivedAtMonotonicMs)
+    || requestElapsedMs < 0
+    || serverTicketLifetimeMs <= 0
+    || serverTicketLifetimeMs > MAXIMUM_SERVER_TICKET_LIFETIME_MS
   ) {
     throw new Error("Invalid response from the ROTK account service");
   }
-  assertLaunchTicketFresh(expiresAt);
-  return {
+  // The authority-issued interval is independent from the workstation clock.
+  // Subtracting the complete HTTPS round trip is deliberately conservative:
+  // issuance happens during that interval, never before it. The game server
+  // still enforces expiry, one-time consumption and account binding.
+  const identity: LaunchTicketIdentity = Object.freeze({
     ticket: response.ticket,
+    issuedAt,
     expiresAt,
+    receivedAtMonotonicMs: timing.receivedAtMonotonicMs,
+    initialRemainingLifetimeMs: serverTicketLifetimeMs - requestElapsedMs,
     rotkId: response.rotkId as string,
     gameAccountGuid,
     steamId: response.steamId as string,
     displayName,
-  };
+  });
+  assertLaunchTicketFresh(identity, MINIMUM_TICKET_LIFETIME_MS, timing.receivedAtMonotonicMs);
+  return identity;
 }
-
 function serviceError(status: number, value: unknown): Error {
   const errorCode = value && typeof value === "object"
     ? (value as Record<string, unknown>).error
@@ -100,6 +163,7 @@ export async function createLaunchTicket(
   if (!isValidPlayerKey(playerKey)) throw new Error("Invalid ROTK player key");
   const endpoint = validateEndpoint(endpointValue);
   const fetchImpl = options.fetchImpl ?? fetch;
+  const requestStartedAtMonotonicMs = performance.now();
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
@@ -128,7 +192,10 @@ export async function createLaunchTicket(
       throw new Error("Invalid response from the ROTK account service");
     }
     if (!response.ok) throw serviceError(response.status, payload);
-    return parseTicketResponse(payload);
+    return parseTicketResponse(payload, {
+      requestStartedAtMonotonicMs,
+      receivedAtMonotonicMs: performance.now(),
+    });
   } finally {
     clearTimeout(timeout);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/tests/launch-ticket.test.ts
+++ b/tests/launch-ticket.test.ts
@@ -1,17 +1,35 @@
 import { describe, expect, it, vi } from "vitest";
-import { createLaunchTicket } from "../electron/services/launch-ticket.js";
+import {
+  assertLaunchTicketFresh,
+  createLaunchTicket,
+  launchTicketInternals,
+} from "../electron/services/launch-ticket.js";
 
 const launcherKey = "0123456789abcdef0123456789abcdef";
 const endpoint = "https://accounts.rotk.app/createLaunchTicket";
-const validResponse = {
-  ok: true,
-  ticket: "T".repeat(43),
-  expiresAt: new Date(Date.now() + 120_000).toISOString(),
-  rotkId: "123e4567-e89b-42d3-a456-426614174000",
-  gameAccountGuid: "9223372036854775807",
-  steamId: "76561198000000001",
-  displayName: "ROTK Player",
-};
+const authorityIssuedAtMs = Date.now();
+
+function validTicketResponse(lifetimeMs = 120_000) {
+  return {
+    ok: true,
+    ticket: "T".repeat(43),
+    issuedAt: new Date(authorityIssuedAtMs).toISOString(),
+    expiresAt: new Date(authorityIssuedAtMs + lifetimeMs).toISOString(),
+    rotkId: "123e4567-e89b-42d3-a456-426614174000",
+    gameAccountGuid: "9223372036854775807",
+    steamId: "76561198000000001",
+    displayName: "ROTK Player",
+  };
+}
+
+const validResponse = validTicketResponse();
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("ROTK launch ticket client", () => {
   it("sends the durable key only in the HTTPS JSON body and validates the identity", async () => {
@@ -21,52 +39,86 @@ describe("ROTK launch ticket client", () => {
       expect(init?.method).toBe("POST");
       expect(init?.headers).toEqual({ Accept: "application/json", "Content-Type": "application/json" });
       expect(init?.body).toBe(JSON.stringify({ launcherKey }));
-      return new Response(JSON.stringify(validResponse), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+      return jsonResponse(validResponse);
     }) as typeof fetch;
 
-    await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl })).resolves.toEqual({
+    const identity = await createLaunchTicket(launcherKey, endpoint, { fetchImpl });
+    expect(identity).toMatchObject({
       ticket: validResponse.ticket,
+      issuedAt: validResponse.issuedAt,
       expiresAt: validResponse.expiresAt,
       rotkId: validResponse.rotkId,
       gameAccountGuid: validResponse.gameAccountGuid,
       steamId: validResponse.steamId,
       displayName: validResponse.displayName,
     });
+    expect(identity.receivedAtMonotonicMs).toBeGreaterThanOrEqual(0);
+    expect(identity.initialRemainingLifetimeMs).toBeGreaterThan(110_000);
+    expect(identity.initialRemainingLifetimeMs).toBeLessThanOrEqual(120_000);
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
+  it("does not reject a valid authority window when the workstation wall clock is wrong", async () => {
+    const wallClock = vi.spyOn(Date, "now").mockReturnValue(authorityIssuedAtMs + 24 * 60 * 60_000);
+    const fetchImpl = vi.fn(async () => jsonResponse(validResponse)) as typeof fetch;
+    try {
+      await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
+        .resolves.toMatchObject({ ticket: validResponse.ticket });
+    } finally {
+      wallClock.mockRestore();
+    }
+  });
+
+  it("tracks freshness from authority lifetime plus monotonic elapsed time", () => {
+    const identity = launchTicketInternals.parseTicketResponse(validResponse, {
+      requestStartedAtMonotonicMs: 1_000,
+      receivedAtMonotonicMs: 1_100,
+    });
+    expect(identity.initialRemainingLifetimeMs).toBe(119_900);
+    expect(() => assertLaunchTicketFresh(identity, 10_000, 110_999)).not.toThrow();
+    expect(() => assertLaunchTicketFresh(identity, 10_000, 111_000))
+      .toThrow("The ROTK launch ticket expires too soon");
+  });
+
   it("fails closed when the key is rejected", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+    const fetchImpl = vi.fn(async () => jsonResponse({
       ok: false,
       error: "invalid_credentials",
       message: "Invalid launcher key",
-    }), { status: 401 })) as typeof fetch;
+    }, 401)) as typeof fetch;
 
     await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
       .rejects.toThrow("The ROTK launcher key was rejected");
   });
 
   it("rejects malformed identity data even after HTTP 200", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+    const fetchImpl = vi.fn(async () => jsonResponse({
       ...validResponse,
       steamId: "not-a-steam-id",
-    }), { status: 200 })) as typeof fetch;
+    })) as typeof fetch;
 
     await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
       .rejects.toThrow("Invalid response from the ROTK account service");
   });
 
-  it("rejects a valid-looking ticket when less than ten seconds remain", async () => {
-    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
-      ...validResponse,
-      expiresAt: new Date(Date.now() + 5_000).toISOString(),
-    }), { status: 200 })) as typeof fetch;
+  it("rejects a server-issued ticket window with less than ten seconds", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(validTicketResponse(5_000))) as typeof fetch;
 
     await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
       .rejects.toThrow("The ROTK launch ticket expires too soon");
+  });
+
+  it("rejects malformed or implausibly long authority windows", () => {
+    expect(() => launchTicketInternals.parseTicketResponse({
+      ...validResponse,
+      issuedAt: "not-a-date",
+    })).toThrow("Invalid response from the ROTK account service");
+    expect(() => launchTicketInternals.parseTicketResponse({
+      ...validResponse,
+      issuedAt: validResponse.issuedAt.replace("Z", "+00:00"),
+    })).toThrow("Invalid response from the ROTK account service");
+    expect(() => launchTicketInternals.parseTicketResponse(validTicketResponse(11 * 60_000)))
+      .toThrow("Invalid response from the ROTK account service");
   });
 
   it("requires an HTTPS endpoint without query parameters", async () => {

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -38,10 +38,6 @@ describe("public ROTK runtime", () => {
 
   it("uses only the account-service Steam identity for the shim environment", () => {
     const environment = gameLauncherInternals.sanitizedEnvironment({
-      ticket: "T".repeat(43),
-      expiresAt: "2026-07-21T12:00:00.000Z",
-      rotkId: "123e4567-e89b-42d3-a456-426614174000",
-      gameAccountGuid: "42",
       steamId: "76561198000000001",
       displayName: "ROTK Player",
     });


### PR DESCRIPTION
## What changed
- release ROTK Launcher v0.3.3
- derive ticket freshness from authority `issuedAt`/`expiresAt`
- track elapsed lifetime with a monotonic process clock
- retain stale-ticket refresh after client preparation
- reject non-canonical timestamps and implausible authority windows

## Root cause
v0.3.2 compared server expiry with the workstation wall clock. A clock-skewed PC rejected every newly issued ticket before H1Z1 spawned, including the refreshed ticket.

## Security
The launcher only performs a conservative usability precheck. The account authority and game server still enforce entropy, hashed storage, server-side expiry, one-time consumption, consumer binding, account role, Steam identity, and active credential validation.

## Validation
- `npm run build`
- 56/56 Vitest tests
- TypeScript typecheck
- Electron and renderer builds
- explicit +24-hour workstation clock-skew test
- malformed timestamp and excessive lifetime rejection tests