### PR TITLE
feat: express install — auto-detect Steam client + recommended ROTK destination

### DIFF
--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -17,7 +17,8 @@ export const CRITICAL_CLIENT_FILES = [
   "steam_api64.dll",
 ] as const;
 
-export const ROTK_INSTALL_DIRECTORY_NAME = "ROTK-H1Z1";
+export const ROTK_INSTALL_DIRECTORY_NAME = "ROTK";
+export const RECOMMENDED_INSTALL_PARENT_NAME = "Games";
 export const INSTALL_MARKER_NAME = ".rotk-installation.json";
 
 export function resolveBundledShimPath(): string {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { join, basename, resolve } from "node:path";
+import { stat } from "node:fs/promises";
+import { join, basename, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   app,
@@ -24,6 +25,7 @@ import {
 import { isAppLocale, type AppLocale } from "../shared/locale.js";
 import {
   APP_NAME,
+  RECOMMENDED_INSTALL_PARENT_NAME,
   ROTK_INSTALL_DIRECTORY_NAME,
   WEBSITE_ORIGIN,
   resolveBundledShimPath,
@@ -32,6 +34,7 @@ import { ConfigStore } from "./services/config-store.js";
 import { adoptExistingClient, installClient } from "./services/installer.js";
 import { GameLauncher, validateInstalledClient } from "./services/game-launcher.js";
 import { classifyClientSource, validateInstallDestination } from "./services/path-policy.js";
+import { locateSteamClient } from "./services/steam-locator.js";
 import { DEFAULT_RUNTIME_CONFIG } from "./services/runtime-config.js";
 import { UpdateFeedService } from "./services/update-feed.js";
 import { LauncherUpdateService } from "./services/launcher-update.js";
@@ -75,6 +78,8 @@ let phase: LauncherPhase = "unconfigured";
 let sourceRoot: string | null = null;
 let destinationRoot: string | null = null;
 let sourceKind: ClientSourceKind | null = null;
+let sourceDetected = false;
+let destinationRecommended = false;
 let progress: LauncherSnapshot["progress"] = null;
 let updates: LauncherSnapshot["updates"] = [];
 let lastErrorRaw: string | null = null;
@@ -101,12 +106,38 @@ async function installationRoot(): Promise<string | null> {
   return (await configStore.load()).installation?.root ?? null;
 }
 
+function recommendedDestinationPath(): string {
+  const systemDrive = process.env.SystemDrive ?? "C:";
+  return join(`${systemDrive}${sep}`, RECOMMENDED_INSTALL_PARENT_NAME, ROTK_INSTALL_DIRECTORY_NAME);
+}
+
+/**
+ * Pre-fill the ROTK destination with the recommended default so a detected or
+ * freshly selected Steam client only needs one Install click. Best-effort: an
+ * already existing folder (the installer requires an empty target) or a
+ * failing path policy leaves the destination for manual selection.
+ */
+async function applyRecommendedDestination(): Promise<void> {
+  if (sourceKind !== "copy-required" || !sourceRoot) return;
+  try {
+    const candidate = recommendedDestinationPath();
+    const existing = await stat(candidate).catch(() => null);
+    if (existing) return;
+    destinationRoot = await validateInstallDestination(candidate, sourceRoot);
+    destinationRecommended = true;
+    phase = "destination-selected";
+  } catch {
+    destinationRoot = null;
+    destinationRecommended = false;
+  }
+}
+
 async function snapshot(): Promise<LauncherSnapshot> {
   const configuredRoot = await installationRoot();
   return {
     appVersion: app.getVersion(),
     phase,
-    selection: { sourceRoot, destinationRoot, sourceKind },
+    selection: { sourceRoot, destinationRoot, sourceKind, sourceDetected, destinationRecommended },
     installationRoot: configuredRoot,
     updates,
     runtime: {
@@ -224,6 +255,36 @@ function registerIpc(): void {
   );
 
   ipcMain.handle(
+    IPC_CHANNELS.detectSource,
+    trustedHandler(async (): Promise<OperationResult<{ sourceRoot: string | null }>> => {
+      const copy = MAIN_COPY[currentLocale];
+      if (gameLauncher.isRunning() || phase === "launching" || phase === "running") {
+        return { ok: false, error: copy.clientInUse };
+      }
+      if (installAbortController) return { ok: false, error: copy.installationInProgress };
+      if (sourceRoot) return { ok: true, value: { sourceRoot } };
+      try {
+        const located = await locateSteamClient();
+        if (!located) return { ok: true, value: { sourceRoot: null } };
+        const selectedClient = await classifyClientSource(located);
+        sourceRoot = selectedClient.root;
+        sourceKind = selectedClient.kind;
+        sourceDetected = true;
+        destinationRoot = null;
+        destinationRecommended = false;
+        phase = "source-selected";
+        await applyRecommendedDestination();
+        lastErrorRaw = null;
+        await broadcastSnapshot();
+        return { ok: true, value: { sourceRoot } };
+      } catch {
+        // Discovery is best-effort: any failure simply leaves the manual flow.
+        return { ok: true, value: { sourceRoot: null } };
+      }
+    }),
+  );
+
+  ipcMain.handle(
     IPC_CHANNELS.selectSource,
     trustedHandler(async (): Promise<OperationResult<{ sourceRoot: string }>> => {
       const copy = MAIN_COPY[currentLocale];
@@ -242,8 +303,11 @@ function registerIpc(): void {
         const selectedClient = await classifyClientSource(selected.filePaths[0]);
         sourceRoot = selectedClient.root;
         sourceKind = selectedClient.kind;
+        sourceDetected = false;
         destinationRoot = null;
+        destinationRecommended = false;
         phase = "source-selected";
+        await applyRecommendedDestination();
         lastErrorRaw = null;
         await broadcastSnapshot();
         return { ok: true, value: { sourceRoot } };
@@ -276,6 +340,7 @@ function registerIpc(): void {
           ? parent
           : join(parent, ROTK_INSTALL_DIRECTORY_NAME);
         destinationRoot = await validateInstallDestination(candidate, sourceRoot);
+        destinationRecommended = false;
         phase = "destination-selected";
         lastErrorRaw = null;
         await broadcastSnapshot();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,6 +10,7 @@ const api: RotkLauncherApi = {
   setLocale: (locale) => ipcRenderer.invoke(IPC_CHANNELS.setLocale, locale),
   setPlayerKey: (playerKey) => ipcRenderer.invoke(IPC_CHANNELS.setPlayerKey, playerKey),
   copyPlayerKey: () => ipcRenderer.invoke(IPC_CHANNELS.copyPlayerKey),
+  detectSource: () => ipcRenderer.invoke(IPC_CHANNELS.detectSource),
   selectSource: () => ipcRenderer.invoke(IPC_CHANNELS.selectSource),
   selectDestination: () => ipcRenderer.invoke(IPC_CHANNELS.selectDestination),
   install: () => ipcRenderer.invoke(IPC_CHANNELS.install),

--- a/electron/services/steam-locator.ts
+++ b/electron/services/steam-locator.ts
@@ -1,0 +1,134 @@
+import { execFile } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, readFile, stat } from "node:fs/promises";
+import { join, normalize } from "node:path";
+import { promisify } from "node:util";
+import { validateClientSource } from "./path-policy.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Steam directory names the H1Z1 client shipped under across its renames.
+ * Every candidate is still validated by content (H1Z1.exe, ClientConfig.ini,
+ * steam_api64.dll), so an unrelated folder with a matching name is rejected.
+ */
+export const STEAM_GAME_DIRECTORY_CANDIDATES = [
+  "H1Z1",
+  "Z1 Battle Royale",
+  "H1Z1 King of the Kill",
+] as const;
+
+export interface SteamLocatorDependencies {
+  readRegistrySteamPath(): Promise<string | null>;
+  readTextFile(path: string): Promise<string | null>;
+  directoryExists(path: string): Promise<boolean>;
+  validateCandidate(path: string): Promise<string>;
+  programFilesX86: string | null;
+  programFiles: string | null;
+}
+
+async function readRegistrySteamPathFromWindows(): Promise<string | null> {
+  if (process.platform !== "win32") return null;
+  try {
+    const { stdout } = await execFileAsync(
+      "reg",
+      ["query", "HKCU\\Software\\Valve\\Steam", "/v", "SteamPath"],
+      { windowsHide: true },
+    );
+    const match = stdout.match(/SteamPath\s+REG_SZ\s+(.+)/i);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+const DEFAULT_DEPENDENCIES: SteamLocatorDependencies = {
+  readRegistrySteamPath: readRegistrySteamPathFromWindows,
+  readTextFile: async (path) => {
+    try {
+      return await readFile(path, "utf8");
+    } catch {
+      return null;
+    }
+  },
+  directoryExists: async (path) => {
+    try {
+      await access(path, fsConstants.R_OK);
+      return (await stat(path)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  validateCandidate: validateClientSource,
+  programFilesX86: process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)",
+  programFiles: process.env.ProgramFiles ?? null,
+};
+
+/**
+ * Extract every library root recorded in Steam's libraryfolders.vdf. The
+ * parser is intentionally tolerant: it only reads `"path" "..."` pairs and
+ * unescapes VDF backslash sequences, because the surrounding structure has
+ * changed across Steam versions.
+ */
+export function parseLibraryFoldersVdf(content: string): string[] {
+  const libraries: string[] = [];
+  const seen = new Set<string>();
+  for (const match of content.matchAll(/"path"\s*"((?:\\.|[^"\\])*)"/gi)) {
+    const raw = match[1].replace(/\\(.)/g, "$1").trim();
+    if (!raw) continue;
+    const library = normalize(raw);
+    const key = library.toLocaleLowerCase("en-US");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    libraries.push(library);
+  }
+  return libraries;
+}
+
+/**
+ * Best-effort discovery of an installed H1Z1 client: Steam root from the
+ * registry (with Program Files fallbacks), every library declared in
+ * libraryfolders.vdf, then each known game directory name. Returns the first
+ * candidate that passes the client-source validation, or null.
+ */
+export async function locateSteamClient(
+  overrides: Partial<SteamLocatorDependencies> = {},
+): Promise<string | null> {
+  const deps: SteamLocatorDependencies = { ...DEFAULT_DEPENDENCIES, ...overrides };
+
+  const steamRoots: string[] = [];
+  const registrySteamPath = await deps.readRegistrySteamPath();
+  if (registrySteamPath) steamRoots.push(normalize(registrySteamPath));
+  for (const programFiles of [deps.programFilesX86, deps.programFiles]) {
+    if (programFiles) steamRoots.push(join(programFiles, "Steam"));
+  }
+
+  const libraries: string[] = [];
+  const seen = new Set<string>();
+  const addLibrary = (library: string): void => {
+    const key = normalize(library).toLocaleLowerCase("en-US");
+    if (seen.has(key)) return;
+    seen.add(key);
+    libraries.push(normalize(library));
+  };
+
+  for (const steamRoot of steamRoots) {
+    if (!(await deps.directoryExists(steamRoot))) continue;
+    addLibrary(steamRoot);
+    const manifest = await deps.readTextFile(join(steamRoot, "steamapps", "libraryfolders.vdf"));
+    if (!manifest) continue;
+    for (const library of parseLibraryFoldersVdf(manifest)) addLibrary(library);
+  }
+
+  for (const library of libraries) {
+    for (const directoryName of STEAM_GAME_DIRECTORY_CANDIDATES) {
+      const candidate = join(library, "steamapps", "common", directoryName);
+      try {
+        return await deps.validateCandidate(candidate);
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -33,6 +33,10 @@ export interface InstallSelection {
   sourceRoot: string | null;
   destinationRoot: string | null;
   sourceKind: ClientSourceKind | null;
+  /** The source was found by automatic Steam discovery, not a manual pick. */
+  sourceDetected: boolean;
+  /** The destination is the launcher-suggested default, not a manual pick. */
+  destinationRecommended: boolean;
 }
 
 export type ClientSourceKind = "direct" | "copy-required";
@@ -91,6 +95,7 @@ export interface RotkLauncherApi {
   setLocale(locale: AppLocale): Promise<void>;
   setPlayerKey(playerKey: string): Promise<OperationResult<PlayerIdentitySummary>>;
   copyPlayerKey(): Promise<OperationResult>;
+  detectSource(): Promise<OperationResult<{ sourceRoot: string | null }>>;
   selectSource(): Promise<OperationResult<{ sourceRoot: string }>>;
   selectDestination(): Promise<OperationResult<{ destinationRoot: string }>>;
   install(): Promise<OperationResult<{ installationRoot: string }>>;
@@ -110,6 +115,7 @@ export const IPC_CHANNELS = {
   setLocale: "launcher:set-locale",
   setPlayerKey: "launcher:set-player-key",
   copyPlayerKey: "launcher:copy-player-key",
+  detectSource: "launcher:detect-source",
   selectSource: "launcher:select-source",
   selectDestination: "launcher:select-destination",
   install: "launcher:install",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ export default function App() {
   const [identityOpen, setIdentityOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [transientError, setTransientError] = useState<string | null>(null);
+  const [detectAttempted, setDetectAttempted] = useState(false);
 
   useEffect(() => {
     setTransientError(null);
@@ -44,6 +45,16 @@ export default function App() {
       unsubscribe();
     };
   }, []);
+
+  // First-run assistance: when the setup panel opens without any selection,
+  // ask the main process to discover the Steam client once per session.
+  useEffect(() => {
+    if (!setupOpen || detectAttempted || !snapshot) return;
+    if (snapshot.installationRoot || snapshot.selection.sourceRoot) return;
+    if (snapshot.phase === "installing") return;
+    setDetectAttempted(true);
+    void window.rotk.detectSource();
+  }, [setupOpen, detectAttempted, snapshot]);
 
   const perform = useCallback(async (operation: () => Promise<OperationResult<unknown>>) => {
     setBusy(true);

--- a/src/components/InstallPanel.tsx
+++ b/src/components/InstallPanel.tsx
@@ -110,7 +110,12 @@ export function InstallPanel({
                 <span className="install-step__index">{hasSource ? <Check size={16} /> : "01"}</span>
                 <FolderOpen size={19} />
                 <span className="install-step__copy">
-                  <strong>{copy.install.sourceClient}</strong>
+                  <strong>
+                    {copy.install.sourceClient}
+                    {snapshot.selection.sourceDetected && (
+                      <span className="install-step__badge">{copy.install.detectedBadge}</span>
+                    )}
+                  </strong>
                   <small title={snapshot.selection.sourceRoot ?? undefined}>{shortPath(snapshot.selection.sourceRoot, copy.install.notSelected)}</small>
                 </span>
                 <span className="install-step__action">{copy.install.choose}</span>
@@ -130,7 +135,12 @@ export function InstallPanel({
                     <span className="install-step__index">{hasDestination ? <Check size={16} /> : "02"}</span>
                     <HardDrive size={19} />
                     <span className="install-step__copy">
-                      <strong>{copy.install.rotkInstall}</strong>
+                      <strong>
+                        {copy.install.rotkInstall}
+                        {snapshot.selection.destinationRecommended && hasDestination && (
+                          <span className="install-step__badge">{copy.install.recommendedBadge}</span>
+                        )}
+                      </strong>
                       <small title={snapshot.selection.destinationRoot ?? undefined}>{shortPath(snapshot.selection.destinationRoot, copy.install.notSelected)}</small>
                     </span>
                     <span className="install-step__action">{copy.install.choose}</span>
@@ -138,6 +148,10 @@ export function InstallPanel({
                 )}
               </AnimatePresence>
             </div>
+
+            {requiresCopy && (
+              <p className="install-panel__hint">{copy.install.subfolderHint}</p>
+            )}
 
             {installing && snapshot.progress ? (
               <div className="copy-progress">

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -111,6 +111,9 @@ export interface Copy {
     steamDetail: string;
     sourceClient: string;
     rotkInstall: string;
+    detectedBadge: string;
+    recommendedBadge: string;
+    subfolderHint: string;
     choose: string;
     cancelCopy: string;
     createInstall: string;
@@ -223,6 +226,9 @@ const COPY: Record<AppLocale, Copy> = {
       steamDetail: "This installation will not be modified. Choose a destination outside Steam for the ROTK copy.",
       sourceClient: "H1Z1 CLIENT",
       rotkInstall: "ROTK INSTALLATION",
+      detectedBadge: "AUTO-DETECTED",
+      recommendedBadge: "RECOMMENDED",
+      subfolderHint: "A ROTK subfolder is created automatically in the chosen location — no need to create it yourself.",
       choose: "CHOOSE",
       cancelCopy: "CANCEL",
       createInstall: "CREATE SEPARATE COPY",
@@ -344,6 +350,9 @@ const COPY: Record<AppLocale, Copy> = {
       steamDetail: "Cette installation ne sera pas modifiée. Choisis un emplacement hors de Steam pour la copie ROTK.",
       sourceClient: "CLIENT H1Z1",
       rotkInstall: "INSTALLATION ROTK",
+      detectedBadge: "DÉTECTÉ AUTO",
+      recommendedBadge: "RECOMMANDÉ",
+      subfolderHint: "Un sous-dossier ROTK est créé automatiquement dans l’emplacement choisi — inutile de le créer toi-même.",
       choose: "CHOISIR",
       cancelCopy: "ANNULER",
       createInstall: "CRÉER UNE COPIE SÉPARÉE",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1259,6 +1259,27 @@ button:focus-visible {
   letter-spacing: 0.1em;
 }
 
+.install-step__badge {
+  margin-left: 8px;
+  padding: 2px 7px;
+  border: 1px solid rgba(230, 64, 52, 0.35);
+  border-radius: 999px;
+  background: rgba(230, 64, 52, 0.1);
+  color: var(--signal);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.install-panel__hint {
+  margin: -6px 0 16px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
 .install-panel__primary {
   width: 100%;
   height: 62px;

--- a/tests/steam-locator.test.ts
+++ b/tests/steam-locator.test.ts
@@ -1,0 +1,163 @@
+import { join, normalize } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  locateSteamClient,
+  parseLibraryFoldersVdf,
+  STEAM_GAME_DIRECTORY_CANDIDATES,
+  type SteamLocatorDependencies,
+} from "../electron/services/steam-locator.js";
+
+const STEAM_ROOT = "C:\\Program Files (x86)\\Steam";
+
+function dependencies(options: {
+  registrySteamPath?: string | null;
+  existingDirectories?: string[];
+  vdfByPath?: Record<string, string>;
+  validClients?: string[];
+}): SteamLocatorDependencies {
+  const existing = new Set(
+    (options.existingDirectories ?? []).map((value) => normalize(value).toLocaleLowerCase("en-US")),
+  );
+  const manifests = new Map(
+    Object.entries(options.vdfByPath ?? {}).map(([path, content]) => [
+      normalize(path).toLocaleLowerCase("en-US"),
+      content,
+    ]),
+  );
+  const valid = new Set(
+    (options.validClients ?? []).map((value) => normalize(value).toLocaleLowerCase("en-US")),
+  );
+  return {
+    readRegistrySteamPath: async () => options.registrySteamPath ?? null,
+    directoryExists: async (path) => existing.has(normalize(path).toLocaleLowerCase("en-US")),
+    readTextFile: async (path) => manifests.get(normalize(path).toLocaleLowerCase("en-US")) ?? null,
+    validateCandidate: async (path) => {
+      if (valid.has(normalize(path).toLocaleLowerCase("en-US"))) return normalize(path);
+      throw new Error(`invalid client: ${path}`);
+    },
+    programFilesX86: "C:\\Program Files (x86)",
+    programFiles: "C:\\Program Files",
+  };
+}
+
+describe("libraryfolders.vdf parsing", () => {
+  it("extracts every library path and unescapes VDF backslashes", () => {
+    const content = `"libraryfolders"
+{
+\t"0"
+\t{
+\t\t"path"\t\t"C:\\\\Program Files (x86)\\\\Steam"
+\t\t"label"\t\t""
+\t}
+\t"1"
+\t{
+\t\t"path"\t\t"D:\\\\SteamLibrary"
+\t\t"apps"
+\t\t{
+\t\t\t"433850"\t\t"31967004052"
+\t\t}
+\t}
+}`;
+    expect(parseLibraryFoldersVdf(content)).toEqual([
+      "C:\\Program Files (x86)\\Steam",
+      "D:\\SteamLibrary",
+    ]);
+  });
+
+  it("deduplicates repeated libraries case-insensitively and skips empty paths", () => {
+    const content = `
+"path"  "D:\\\\SteamLibrary"
+"path"  "d:\\\\steamlibrary"
+"path"  ""
+`;
+    expect(parseLibraryFoldersVdf(content)).toEqual(["D:\\SteamLibrary"]);
+  });
+
+  it("returns no library for unrelated content", () => {
+    expect(parseLibraryFoldersVdf(`"contentstatsid" "123"`)).toEqual([]);
+  });
+});
+
+describe("Steam client discovery", () => {
+  it("finds the H1Z1 client under the registry Steam root", async () => {
+    const client = join(STEAM_ROOT, "steamapps", "common", "H1Z1");
+    const located = await locateSteamClient(
+      dependencies({
+        registrySteamPath: "C:/Program Files (x86)/Steam",
+        existingDirectories: [STEAM_ROOT],
+        validClients: [client],
+      }),
+    );
+    expect(located).toBe(normalize(client));
+  });
+
+  it("falls back to the Program Files Steam root when the registry has no entry", async () => {
+    const client = join(STEAM_ROOT, "steamapps", "common", "H1Z1");
+    const located = await locateSteamClient(
+      dependencies({
+        registrySteamPath: null,
+        existingDirectories: [STEAM_ROOT],
+        validClients: [client],
+      }),
+    );
+    expect(located).toBe(normalize(client));
+  });
+
+  it("finds a client living in a secondary library on another drive", async () => {
+    const client = "D:\\SteamLibrary\\steamapps\\common\\H1Z1";
+    const located = await locateSteamClient(
+      dependencies({
+        registrySteamPath: STEAM_ROOT,
+        existingDirectories: [STEAM_ROOT],
+        vdfByPath: {
+          [join(STEAM_ROOT, "steamapps", "libraryfolders.vdf")]:
+            `"path"  "D:\\\\SteamLibrary"`,
+        },
+        validClients: [client],
+      }),
+    );
+    expect(located).toBe(normalize(client));
+  });
+
+  it("tries every historical game directory name", async () => {
+    expect(STEAM_GAME_DIRECTORY_CANDIDATES).toContain("H1Z1");
+    const client = join(STEAM_ROOT, "steamapps", "common", "Z1 Battle Royale");
+    const located = await locateSteamClient(
+      dependencies({
+        registrySteamPath: STEAM_ROOT,
+        existingDirectories: [STEAM_ROOT],
+        validClients: [client],
+      }),
+    );
+    expect(located).toBe(normalize(client));
+  });
+
+  it("returns null when no Steam root exists", async () => {
+    const located = await locateSteamClient(
+      dependencies({ registrySteamPath: null, existingDirectories: [] }),
+    );
+    expect(located).toBeNull();
+  });
+
+  it("returns null when no candidate passes the client validation", async () => {
+    const located = await locateSteamClient(
+      dependencies({
+        registrySteamPath: STEAM_ROOT,
+        existingDirectories: [STEAM_ROOT],
+        validClients: [],
+      }),
+    );
+    expect(located).toBeNull();
+  });
+
+  it("checks each candidate only once when registry and defaults overlap", async () => {
+    const deps = dependencies({
+      registrySteamPath: "c:/program files (x86)/steam",
+      existingDirectories: [STEAM_ROOT],
+      validClients: [],
+    });
+    const validateCandidate = vi.fn(deps.validateCandidate);
+    await locateSteamClient({ ...deps, validateCandidate });
+    expect(validateCandidate).toHaveBeenCalledTimes(STEAM_GAME_DIRECTORY_CANDIDATES.length);
+  });
+});


### PR DESCRIPTION
Closes #4

## Quoi

- **Nouveau service [`electron/services/steam-locator.ts`]** : localise le client H1Z1 via le registre (`SteamPath`), replis Program Files, parsing tolérant de `libraryfolders.vdf` (multi-disques), noms historiques (`H1Z1`, `Z1 Battle Royale`, `H1Z1 King of the Kill`). Chaque candidat est validé par `validateClientSource` (contenu, pas seulement le nom). Dépendances injectables pour les tests.
- **Nouveau canal IPC `launcher:detect-source`** : déclenché par le renderer à l'ouverture du panneau d'installation quand rien n'est sélectionné (une fois par session). Réutilise `classifyClientSource` — un chemin Steam reste `copy-required`.
- **Destination recommandée** : quand la source exige une copie, `%SystemDrive%\Games\ROTK` est pré-rempli (après `validateInstallDestination` + refus si le dossier existe déjà, l'installeur exigeant une cible vide). La sélection manuelle écrase simplement la recommandation.
- **UI** : badges « DÉTECTÉ AUTO » / « RECOMMANDÉ » sur les étapes, note expliquant que le sous-dossier ROTK est créé automatiquement dans l'emplacement choisi.
- **Renommage** : `ROTK_INSTALL_DIRECTORY_NAME` passe de `ROTK-H1Z1` à `ROTK`. Sans impact sur les installations existantes (racine stockée dans la config).
- **i18n** : nouvelles chaînes FR/EN.
- **Bump version 0.4.0.**

## Pourquoi

Voir #4 : dans le cas nominal (client Steam standard), la première configuration se réduit à un seul clic sur **Installer** ; et l'UI cesse de laisser croire qu'il faut créer le dossier d'installation soi-même.

## Sécurité

- Aucune modification de la path-policy : tous les chemins (détectés, recommandés, manuels) passent par les validations existantes.
- La détection est best-effort : tout échec retombe silencieusement sur le flux manuel.
- `reg.exe` est invoqué via `execFile` (pas de shell), lecture seule de `HKCU\Software\Valve\Steam`.

## Tests

- `tests/steam-locator.test.ts` : parsing vdf (échappements, dédoublonnage, contenu inattendu), découverte via registre / repli Program Files / bibliothèque secondaire sur autre disque / variantes de noms, absence de Steam, aucun candidat valide, dédoublonnage des racines.
- `npm run typecheck`, `npm test` (66 tests, 13 fichiers) et `npm run build` passent.

## Test manuel suggéré

1. `npm run dev:isolated` sur une machine avec H1Z1 Steam installé → le panneau s'ouvre avec la source détectée (badge) et `C:\Games\ROTK` pré-rempli → un clic INSTALLER.
2. Vérifier le remplacement manuel de la destination (badge disparaît).
3. Machine sans Steam → flux manuel inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
