### PR TITLE
feat(launcher): configure secure Vivox voice grants

### DIFF
--- a/contracts/runtime-manifest.v1.schema.json
+++ b/contracts/runtime-manifest.v1.schema.json
@@ -11,6 +11,7 @@
     "expiresAt",
     "minLauncherVersion",
     "gatewayOrigin",
+    "voiceGrantOrigin",
     "loginEndpoints",
     "websiteOrigin",
     "keyId",
@@ -23,6 +24,10 @@
     "expiresAt": { "type": "string", "format": "date-time" },
     "minLauncherVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
     "gatewayOrigin": { "type": "string", "pattern": "^https://" },
+    "voiceGrantOrigin": {
+      "type": "string",
+      "pattern": "^https://[^/?#]+$"
+    },
     "loginEndpoints": {
       "type": "array",
       "minItems": 1,

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -108,12 +108,14 @@ function buildLaunchArguments(
   localCreateSessionUrl: string,
 ): string[] {
   const gatewayCreateSession = validateLocalCreateSessionUrl(localCreateSessionUrl);
+  const voiceGrantOrigin = validateVoiceGrantOrigin(runtime.voiceGrantOrigin);
   const localLogs = join(logsRoot, installId, "local");
   const failureLogs = join(logsRoot, installId, "failure");
   return [
     `sessionid=${launchTicket}`,
     `server=${serverList(runtime)}`,
     `SteamGatewayUrl=${gatewayCreateSession}`,
+    `VivoxGrantUrl=${voiceGrantOrigin}`,
     `CommandQueue:motd_uri=${runtime.gatewayOrigin}/`,
     `CommandQueue:cb_uri=${runtime.gatewayOrigin}/`,
     `CommandQueue:eula_uri=${runtime.gatewayOrigin}/`,
@@ -125,6 +127,26 @@ function buildLaunchArguments(
     `Logging:LocalDirectory=${localLogs}`,
     `Logging:FailureDirectory=${failureLogs}`,
   ];
+}
+
+function validateVoiceGrantOrigin(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error("Invalid ROTK voice grant origin");
+  }
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.pathname !== "/" ||
+    parsed.search !== "" ||
+    parsed.hash !== "" ||
+    parsed.username !== "" ||
+    parsed.password !== ""
+  ) {
+    throw new Error("Invalid ROTK voice grant origin");
+  }
+  return parsed.origin;
 }
 
 export class GameLauncher {
@@ -225,4 +247,5 @@ export const gameLauncherInternals = {
   validateInstalledClient,
   prepareClient,
   buildLaunchArguments,
+  validateVoiceGrantOrigin,
 };

--- a/electron/services/runtime-config.ts
+++ b/electron/services/runtime-config.ts
@@ -2,6 +2,8 @@ export interface RuntimeConfig {
   environment: "development" | "production";
   label: string;
   gatewayOrigin: string;
+  /** Public HTTPS origin used only to obtain short-lived, scoped voice grants. */
+  voiceGrantOrigin: string;
   loginHost: string;
   loginPorts: number[];
   websiteOrigin: string;
@@ -17,6 +19,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   environment: "production",
   label: "ROTK Europe",
   gatewayOrigin: "http://51.255.160.224",
+  voiceGrantOrigin: "https://vps-c717eb9e.vps.ovh.net",
   loginHost: "51.255.160.224",
   loginPorts: [20042, 20043, 20044, 20045],
   websiteOrigin: "https://rotk.app",

--- a/tests/client-config.test.ts
+++ b/tests/client-config.test.ts
@@ -9,6 +9,7 @@ const runtime: RuntimeConfig = {
   environment: "production",
   label: "ROTK Europe",
   gatewayOrigin: "https://gateway.rotk.app",
+  voiceGrantOrigin: "https://voice.rotk.app",
   loginHost: "login.rotk.app",
   loginPorts: [20042, 20043],
   websiteOrigin: "https://rotk.app",

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -6,6 +6,9 @@ describe("public ROTK runtime", () => {
   it("targets the OVH gateway and every public login listener", () => {
     expect(DEFAULT_RUNTIME_CONFIG.environment).toBe("production");
     expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://51.255.160.224");
+    expect(DEFAULT_RUNTIME_CONFIG.voiceGrantOrigin).toBe(
+      "https://vps-c717eb9e.vps.ovh.net",
+    );
     expect(serverList(DEFAULT_RUNTIME_CONFIG)).toBe(
       "51.255.160.224:20042;51.255.160.224:20043;51.255.160.224:20044;51.255.160.224:20045",
     );
@@ -30,10 +33,35 @@ describe("public ROTK runtime", () => {
     expect(args).toContain(
       "SteamGatewayUrl=http://127.0.0.1:49152/rest/auth/session/create",
     );
+    expect(args).toContain(
+      "VivoxGrantUrl=https://vps-c717eb9e.vps.ovh.net",
+    );
     expect(args).toContain("CommandQueue:motd_uri=http://51.255.160.224/");
     expect(args.some((argument) => (
       argument.includes("51.255.160.224/rest/auth/session/create")
     ))).toBe(false);
+    expect(args.join(" ")).not.toMatch(
+      /token.?key|private.?key|client.?secret|password/i,
+    );
+  });
+
+  it("accepts only a credential-free HTTPS origin for voice grants", () => {
+    expect(
+      gameLauncherInternals.validateVoiceGrantOrigin("https://voice.rotk.app"),
+    ).toBe("https://voice.rotk.app");
+    expect(() =>
+      gameLauncherInternals.validateVoiceGrantOrigin("http://voice.rotk.app"),
+    ).toThrow(/voice grant origin/i);
+    expect(() =>
+      gameLauncherInternals.validateVoiceGrantOrigin(
+        "https://user:password@voice.rotk.app",
+      ),
+    ).toThrow(/voice grant origin/i);
+    expect(() =>
+      gameLauncherInternals.validateVoiceGrantOrigin(
+        "https://voice.rotk.app/voice/v1/login?token=secret",
+      ),
+    ).toThrow(/voice grant origin/i);
   });
 
   it("uses only the account-service Steam identity for the shim environment", () => {


### PR DESCRIPTION
## Summary

- add `voiceGrantOrigin` to the signed runtime manifest contract and launcher runtime configuration
- pass the validated HTTPS origin to the game through `VivoxGrantUrl`
- reject credentials, paths, query strings, fragments, and non-HTTPS voice grant origins
- cover runtime configuration and launch argument behavior with tests

## Why

The game client needs a public endpoint for short-lived, scoped Vivox grants. The launcher must provide only a credential-free HTTPS origin so signing keys and long-lived secrets never enter the client command line.

## Validation

- `npm run typecheck`
- `npm test` — 13 files, 67 tests passed
- Electron build passed
- renderer production build passed
