### PR TITLE
Fix official Vivox 5 client detection

### DIFF
--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -93,6 +93,12 @@ const ENGLISH_ERRORS = new Map<string, string>([
   ["Installe d’abord le client ROTK.", "Install the ROTK client first."],
   ["Windows n’a pas retourné l’identifiant du processus H1Z1.", "Windows did not return an H1Z1 process identifier."],
   ["Cette version de H1Z1 n’est pas encore prise en charge par ROTK. Vérifie les fichiers du jeu dans Steam puis réessaie.", "This H1Z1 version is not supported by ROTK yet. Verify the game files in Steam and try again."],
+  ["Le proxy vocal ROTK embarqué est invalide.", "The bundled ROTK voice proxy is invalid."],
+  ["Le SDK Vivox historique est introuvable.", "The legacy Vivox SDK could not be found."],
+  ["La version Vivox 5 attendue est absente du client H1Z1.", "The required Vivox 5 version is missing from the H1Z1 client."],
+  ["Le SDK Vivox actif est inconnu; vérifie les fichiers H1Z1.", "The active Vivox SDK is unknown. Verify the H1Z1 files."],
+  ["La sauvegarde du SDK Vivox historique est invalide.", "The legacy Vivox SDK backup is invalid."],
+  ["Le proxy vocal ROTK n'a pas été copié correctement.", "The ROTK voice proxy was not copied correctly."],
 ]);
 
 const FRENCH_ERRORS = new Map<string, string>([

--- a/electron/services/vivox-client.ts
+++ b/electron/services/vivox-client.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 export const VIVOX_STOCK_V4_SHA256 =
   "d6915a466a905ae55f7e20019e01228c92cc86ce793a9fc050b49258a210c7b1";
 export const VIVOX_STOCK_V5_SHA256 =
-  "33a7f704eda23dda9ccbd9eba1fda2f0589211e9c61ec9d1f9c797f2dcbf65f9";
+  "33a7f704eda23dda9ccbd9eba1fda2f0589211e9c61ec9d1f9c797acc624ea44";
 
 async function sha256(filePath: string): Promise<string> {
   const hash = createHash("sha256");
@@ -33,6 +33,7 @@ export async function deployVivoxCompatibility(
 
   const activePath = join(root, "vivoxsdk_x64.dll");
   const backupPath = join(root, "vivoxsdk_x64.original.dll");
+  const legacyBackupPath = join(root, "vivoxsdk_x64_original.dll");
   const v5Path = join(root, "vivoxsdk_x64_v5.dll");
   const active = await stat(activePath).catch(() => null);
   if (!active?.isFile()) throw new Error("Le SDK Vivox historique est introuvable.");
@@ -40,13 +41,21 @@ export async function deployVivoxCompatibility(
     throw new Error("La version Vivox 5 attendue est absente du client H1Z1.");
   }
 
-  const backup = await stat(backupPath).catch(() => null);
+  let backup = await stat(backupPath).catch(() => null);
   if (backup === null) {
-    if (await sha256(activePath) !== VIVOX_STOCK_V4_SHA256) {
-      throw new Error("Le SDK Vivox actif est inconnu; vérifie les fichiers H1Z1.");
+    const legacyBackupHash = await sha256(legacyBackupPath).catch(() => "");
+    if (legacyBackupHash === VIVOX_STOCK_V4_SHA256) {
+      await copyFile(legacyBackupPath, backupPath, fsConstants.COPYFILE_EXCL);
+      backup = await stat(backupPath);
+    } else {
+      if (await sha256(activePath) !== VIVOX_STOCK_V4_SHA256) {
+        throw new Error("Le SDK Vivox actif est inconnu; vérifie les fichiers H1Z1.");
+      }
+      await copyFile(activePath, backupPath, fsConstants.COPYFILE_EXCL);
+      backup = await stat(backupPath);
     }
-    await copyFile(activePath, backupPath, fsConstants.COPYFILE_EXCL);
-  } else if (!backup.isFile() || await sha256(backupPath) !== VIVOX_STOCK_V4_SHA256) {
+  }
+  if (!backup.isFile() || await sha256(backupPath) !== VIVOX_STOCK_V4_SHA256) {
     throw new Error("La sauvegarde du SDK Vivox historique est invalide.");
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -14,6 +14,12 @@ describe("launcher locales", () => {
     expect(
       localizeServiceError("Client H1Z1 incomplet : H1Z1.exe est introuvable.", "en"),
     ).toBe("Incomplete H1Z1 client: H1Z1.exe could not be found.");
+    expect(
+      localizeServiceError(
+        "La version Vivox 5 attendue est absente du client H1Z1.",
+        "en",
+      ),
+    ).toBe("The required Vivox 5 version is missing from the H1Z1 client.");
   });
 
   it("localizes internal English errors for the French interface", () => {


### PR DESCRIPTION
## What changed
- correct the pinned SHA-256 for the signed Vivox 5.27.1.33971 DLL shipped with the supported H1Z1 client
- migrate the legacy underscore-named Vivox 4 backup without overwriting it
- localize all Vivox deployment errors for English launcher users
- prepare launcher v0.5.2

## Validation
- official DLL Authenticode signature verified locally as Unity Technologies
- full deployment exercised against the supported local client layout
- npm run build:vivox
- npm run build (67 tests passed)