### PR TITLE
feat(integrity): attest game files to the server before launch

### DIFF
--- a/docs/asset-packs.md
+++ b/docs/asset-packs.md
@@ -94,19 +94,26 @@ The launcher refuses the whole pack if any rule fails — nothing is written hal
 - Zips: plain store/deflate central-directory archives only (no zip64, no encryption),
   ≤ 20 000 entries, per-entry and total uncompressed sizes are bounded and enforced
   during inflation (zip-bomb guard).
-- Sizes: ≤ 512 MB per asset, ≤ 2 GB total.
+- Sizes: ≤ 3 GB per asset (also bounds a single extracted zip entry — the main
+  game pack is 2.47 GB uncompressed), ≤ 8 GB total. GitHub caps each release
+  asset at 2 GiB, which is why big packs ship compressed, one zip per pack.
 
 ## 5. Publishing checklist
 
-1. Build the payloads (`.zip` for trees, plain files otherwise). Avoid blocked
-   extensions and protected paths (section 4).
-2. Compute for each payload: `sha256` (`Get-FileHash -Algorithm SHA256 <file>`) and
-   size in bytes.
-3. Create the GitHub release `assets-vX.Y.Z` on `h1z1rotk/assets` and attach the payloads.
-4. Update `feed.json` on `main`: new URLs, `sha256`, `size`, bumped `version` for the
-   changed assets and a bumped `packVersion`.
-5. Done — launchers pick the update up at the next launch. To roll back, point
+1. Run `scripts/package-asset-packs.ps1 -SourceDirectory <packs dir>
+   -OutputDirectory <out> -PackVersion X.Y.Z`. It zips **each file into its own
+   payload** (so launcher updates only re-download what changed), enforces the
+   section 4 caps and blocked extensions, computes `sha256`/`size` and writes
+   the ready-to-commit `feed.json`.
+2. Create the GitHub release `assets-vX.Y.Z` on `h1z1rotk/assets` and attach the
+   generated zips.
+3. Commit the generated `feed.json` to `main`.
+4. Done — launchers pick the update up at the next launch. To roll back, point
    `feed.json` back to the previous release assets.
+
+Manual fallback: build payloads yourself (avoid blocked extensions and
+protected paths), `Get-FileHash -Algorithm SHA256`, then edit `feed.json` by
+hand (bump `version` per changed asset and `packVersion`).
 
 ## 6. Launcher UX
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -52,6 +52,19 @@ import {
   type PlayerIdentity,
 } from "./services/player-identity.js";
 import { PlayerKeyStore } from "./services/player-key-store.js";
+import { readInstallationMarker } from "./services/installer.js";
+import {
+  BASE_MANIFEST_URL,
+  loadBaseManifest,
+  mergeExpectedFiles,
+  readLauncherOverrides,
+} from "./services/base-manifest.js";
+import {
+  buildAttestationResult,
+  measureInstallation,
+  requestAttestationChallenge,
+  type AttestationProgress,
+} from "./services/integrity-attestation.js";
 
 app.setName(APP_NAME);
 if (!app.isPackaged && process.env.ROTK_USER_DATA_DIR) {
@@ -100,6 +113,7 @@ let assetSyncRunning = false;
 let assetSyncStatus: AssetSyncStatus = "idle";
 let assetSyncWarning: AssetSyncWarning | null = null;
 let assetSyncProgress: AssetSyncProgress | null = null;
+let attestationProgress: AttestationProgress | null = null;
 let assetSyncPackVersion: string | null = null;
 let assetSyncLastAt: string | null = null;
 
@@ -199,6 +213,78 @@ async function runAssetSync(mode: "sync" | "verify", soft: boolean): Promise<Ope
   }
 }
 
+/**
+ * Runs one integrity attestation pass and returns the block the launch ticket
+ * request carries. Returns null only when attestation genuinely cannot run
+ * (no policy published, manifest unreachable and never cached) — it is the
+ * backend, not the launcher, that decides whether a null is acceptable.
+ *
+ * A tampered installation still attests: the deviations are reported and the
+ * evidence will not match, so the rejection is logged for the admin studio
+ * instead of being silently hidden by the client.
+ */
+async function attestInstallation(playerKey: string): Promise<unknown | null> {
+  const root = await installationRoot();
+  if (!root) return null;
+  const userDataDirectory = app.getPath("userData");
+  const launcherVersion = app.getVersion();
+  try {
+    const marker = await readInstallationMarker(root);
+    if (!marker) return null;
+
+    const challenge = await requestAttestationChallenge(
+      playerKey,
+      DEFAULT_RUNTIME_CONFIG.attestationChallengeUrl,
+      launcherVersion,
+    );
+    const baseManifest = await loadBaseManifest({
+      url: BASE_MANIFEST_URL,
+      userDataDirectory,
+      expectedBuildId: challenge.baseBuildId,
+    });
+    const assetState = await assetSync.readState().catch(() => null);
+    const installedAssets = (assetState?.assets ?? []).flatMap((asset) =>
+      asset.installedFiles.map((file) => ({
+        path: file.path,
+        size: file.size,
+        sha256: file.sha256,
+      })));
+    // The shim replaces steam_api64.dll: expect the launcher's artifact, not
+    // the vanilla hash, so the file stays attested instead of excluded.
+    const overrides = await readLauncherOverrides([
+      { installPath: "steam_api64.dll", bundledPath: resolveBundledShimPath() },
+    ]);
+
+    const measurement = await measureInstallation({
+      installationRoot: root,
+      userDataDirectory,
+      expected: mergeExpectedFiles(baseManifest.files, installedAssets, overrides),
+      // Report undeclared .pack2/.dll/.exe dropped into the game tree. Costs
+      // one directory walk; the per-file hashing dominates anyway.
+      detectUnexpected: true,
+      onProgress: (progress) => {
+        attestationProgress = progress.phase === "done" ? null : progress;
+        void broadcastSnapshot();
+      },
+    });
+    attestationProgress = null;
+    if (measurement.deviations.length > 0) {
+      console.warn(
+        `Integrity attestation found ${measurement.deviations.length} deviation(s); reporting them.`,
+      );
+    }
+    return buildAttestationResult(challenge, measurement, launcherVersion);
+  } catch (error) {
+    attestationProgress = null;
+    // A challenge or manifest we cannot obtain is reported as "no attestation";
+    // the backend applies its enforcement policy to that.
+    console.warn("Integrity attestation could not complete", {
+      message: error instanceof Error ? error.message : "unknown",
+    });
+    return null;
+  }
+}
+
 async function snapshot(): Promise<LauncherSnapshot> {
   const configuredRoot = await installationRoot();
   return {
@@ -215,6 +301,14 @@ async function snapshot(): Promise<LauncherSnapshot> {
     playerIdentity: identitySummary(),
     launcherUpdate: launcherUpdate.state,
     assetSync: assetSyncSummary(),
+    integrityCheck: attestationProgress
+      ? {
+        hashedFiles: attestationProgress.hashedFiles,
+        totalFiles: attestationProgress.totalFiles,
+        hashedBytes: attestationProgress.hashedBytes,
+        totalBytes: attestationProgress.totalBytes,
+      }
+      : null,
     progress,
     error: lastErrorRaw ? localizeServiceError(lastErrorRaw, currentLocale) : null,
     gamePid,
@@ -528,6 +622,7 @@ function registerIpc(): void {
           bundledShimPath: resolveBundledShimPath(),
           bundledVivoxProxyPath: resolveBundledVivoxProxyPath(),
           bundledVivoxRuntimePath: resolveBundledVivoxRuntimePath(),
+          attest: () => attestInstallation(launchCredential.playerKey),
           onExit: () => {
             gamePid = null;
             phase = "ready";

--- a/electron/services/asset-sync.ts
+++ b/electron/services/asset-sync.ts
@@ -44,8 +44,13 @@ const ASSET_REDIRECT_HOSTS = new Set([
 
 const MAX_FEED_BYTES = 1_000_000;
 const MAX_ASSETS = 64;
-const MAX_ASSET_BYTES = 512 * 1024 * 1024;
-const MAX_TOTAL_ASSET_BYTES = 2 * 1024 * 1024 * 1024;
+/**
+ * Also bounds a single extracted zip entry: the main game pack
+ * (assets_x64_0.pack2) is 2.47 GB uncompressed. Entries must stay below
+ * 4 GiB regardless — the zip reader rejects Zip64 archives.
+ */
+const MAX_ASSET_BYTES = 3 * 1024 * 1024 * 1024;
+const MAX_TOTAL_ASSET_BYTES = 8 * 1024 * 1024 * 1024;
 const MAX_ZIP_ENTRIES = 20_000;
 const MAX_REDIRECTS = 5;
 const MANIFEST_TIMEOUT_MS = 10_000;
@@ -124,6 +129,14 @@ function manifestError(reason: string): Error {
 
 function isHex64(value: unknown): value is string {
   return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
+/**
+ * JSON.parse rejects a leading BOM, and Windows tooling emits one by default.
+ * A feed published with a BOM would otherwise stop every launcher.
+ */
+export function stripByteOrderMark(value: string): string {
+  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value;
 }
 
 function hasBlockedExtension(fileName: string): boolean {
@@ -484,7 +497,7 @@ export class AssetSyncService {
       const response = await this.fetchFollowingRedirects(this.feedUrl, controller.signal);
       const body = await response.text();
       if (Buffer.byteLength(body, "utf8") > MAX_FEED_BYTES) throw new Error("Feed too large");
-      return parseAssetManifest(JSON.parse(body));
+      return parseAssetManifest(JSON.parse(stripByteOrderMark(body)));
     } finally {
       clearTimeout(timeout);
       signal?.removeEventListener("abort", abortUpstream);

--- a/electron/services/base-manifest.ts
+++ b/electron/services/base-manifest.ts
@@ -1,0 +1,232 @@
+/**
+ * Fetches and verifies the signed BASE_MANIFEST — the authoritative list of
+ * pristine game files for a supported client build.
+ *
+ * The manifest is public and cacheable; its authenticity comes from the Ed25519
+ * signature of a pinned release key, so mirroring or caching it is harmless.
+ * A manifest that fails verification is discarded, never used.
+ */
+
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { stripByteOrderMark } from "./asset-sync.js";
+import {
+  isAttestationExcluded,
+  isManifestPath,
+  isSha256Hex,
+  manifestSigningInput,
+  verifyAttestationSignature,
+  type ManifestFileEntry,
+} from "../../shared/attestation.js";
+
+/** Published beside the asset packs, in the same public repository. */
+export const BASE_MANIFEST_URL =
+  "https://raw.githubusercontent.com/h1z1rotk/assets/main/base-manifest.v1.json";
+
+const CACHE_FILE_NAME = "base-manifest.v1.json";
+const MAX_MANIFEST_BYTES = 32 * 1024 * 1024;
+const MAX_MANIFEST_FILES = 200_000;
+const DEFAULT_TIMEOUT_MS = 20_000;
+/** Same allowlist as the asset feed: manifests ship beside the packs. */
+const MANIFEST_HOSTS = new Set(["github.com", "raw.githubusercontent.com", "objects.githubusercontent.com", "release-assets.githubusercontent.com"]);
+
+export interface BaseManifest {
+  schemaVersion: 1;
+  kind: "base-game";
+  buildId: string;
+  root: string;
+  fileCount: number;
+  totalBytes: number;
+  issuedAt: string;
+  keyId: string;
+  signature: string;
+  files: ManifestFileEntry[];
+}
+
+function manifestError(reason: string): Error {
+  return new Error(`Manifeste du jeu de base invalide : ${reason}.`);
+}
+
+export function parseBaseManifest(value: unknown): BaseManifest {
+  if (!value || typeof value !== "object") throw manifestError("structure inattendue");
+  const manifest = value as Record<string, unknown>;
+  if (manifest.schemaVersion !== 1) throw manifestError("version non prise en charge");
+  if (manifest.kind !== "base-game") throw manifestError("type inattendu");
+  for (const field of ["buildId", "issuedAt", "keyId", "signature"] as const) {
+    if (typeof manifest[field] !== "string" || (manifest[field] as string).length === 0) {
+      throw manifestError(`champ ${field} manquant`);
+    }
+  }
+  if (!isSha256Hex(manifest.root)) throw manifestError("racine invalide");
+  if (!Array.isArray(manifest.files) || manifest.files.length === 0) throw manifestError("aucun fichier");
+  if (manifest.files.length > MAX_MANIFEST_FILES) throw manifestError("trop de fichiers");
+
+  const files: ManifestFileEntry[] = [];
+  const seen = new Set<string>();
+  let totalBytes = 0;
+  for (const raw of manifest.files as Array<Record<string, unknown>>) {
+    if (!raw || typeof raw !== "object") throw manifestError("entrée inattendue");
+    const { path, size, sha256 } = raw;
+    if (!isManifestPath(path)) throw manifestError("chemin invalide");
+    if (!isSha256Hex(sha256)) throw manifestError("empreinte invalide");
+    if (typeof size !== "number" || !Number.isSafeInteger(size) || size < 0) throw manifestError("taille invalide");
+    const key = (path as string).toLowerCase();
+    if (seen.has(key)) throw manifestError("chemin en double");
+    seen.add(key);
+    totalBytes += size;
+    files.push({ path: path as string, size, sha256: sha256 as string });
+  }
+
+  // Signature covers the identity fields and the root; the file list is bound
+  // to it because the root is derived from the list (verified by the caller
+  // recomputing it).
+  const signed = verifyAttestationSignature(
+    manifestSigningInput({
+      kind: "base-game",
+      schemaVersion: 1,
+      version: manifest.buildId as string,
+      root: manifest.root,
+      issuedAt: manifest.issuedAt as string,
+      expiresAt: null,
+    }),
+    manifest.signature,
+    manifest.keyId,
+  );
+  if (!signed) throw manifestError("signature non reconnue");
+
+  return {
+    schemaVersion: 1,
+    kind: "base-game",
+    buildId: manifest.buildId as string,
+    root: manifest.root,
+    fileCount: files.length,
+    totalBytes,
+    issuedAt: manifest.issuedAt as string,
+    keyId: manifest.keyId as string,
+    signature: manifest.signature as string,
+    files,
+  };
+}
+
+function validateManifestUrl(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw manifestError("URL invalide");
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) throw manifestError("URL invalide");
+  if (!MANIFEST_HOSTS.has(parsed.hostname)) throw manifestError(`hôte non autorisé (${parsed.hostname})`);
+  return parsed.href;
+}
+
+export interface LoadBaseManifestOptions {
+  url: string;
+  userDataDirectory: string;
+  expectedBuildId: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+/**
+ * Returns the verified manifest for `expectedBuildId`, preferring the network
+ * and falling back to the cached copy (also re-verified) when offline.
+ */
+export async function loadBaseManifest(options: LoadBaseManifestOptions): Promise<BaseManifest> {
+  const url = validateManifestUrl(options.url);
+  const cachePath = join(options.userDataDirectory, CACHE_FILE_NAME);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      redirect: "follow",
+      signal: controller.signal,
+    });
+    if (!response.ok) throw manifestError(`téléchargement refusé (${response.status})`);
+    const text = await response.text();
+    if (text.length > MAX_MANIFEST_BYTES) throw manifestError("manifeste trop volumineux");
+    const manifest = parseBaseManifest(JSON.parse(stripByteOrderMark(text)));
+    if (manifest.buildId !== options.expectedBuildId) {
+      throw manifestError(`build inattendu (${manifest.buildId})`);
+    }
+    await writeFile(cachePath, text, { encoding: "utf8", mode: 0o600 }).catch(() => undefined);
+    return manifest;
+  } catch (networkError) {
+    const cached = await readFile(cachePath, "utf8").catch(() => null);
+    if (cached === null) throw networkError;
+    const manifest = parseBaseManifest(JSON.parse(stripByteOrderMark(cached)));
+    if (manifest.buildId !== options.expectedBuildId) throw networkError;
+    return manifest;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Expected installation state = pristine base tree with launcher-installed
+ * asset files layered on top (an asset legitimately replaces a base file).
+ *
+ * Per-player settings and launcher-rewritten files are dropped so a conforming
+ * installation hashes to a stable root — see ATTESTATION_EXCLUDED_PATHS for the
+ * inclusion criteria. `overrides` carries the launcher's own replacements
+ * (shim DLLs), which stay attested against the replacement hash.
+ */
+export function mergeExpectedFiles(
+  base: readonly ManifestFileEntry[],
+  installedAssets: readonly ManifestFileEntry[],
+  overrides: readonly ManifestFileEntry[] = [],
+): ManifestFileEntry[] {
+  const byKey = new Map<string, ManifestFileEntry>();
+  for (const group of [base, installedAssets, overrides]) {
+    for (const entry of group) {
+      if (isAttestationExcluded(entry.path)) continue;
+      byKey.set(entry.path.toLowerCase(), entry);
+    }
+  }
+  return [...byKey.values()];
+}
+
+/** Re-exported for callers; the canonical rule lives in shared/attestation.ts. */
+export { isAttestationExcluded } from "../../shared/attestation.js";
+
+/**
+ * Expected hashes for the files the launcher deliberately replaces.
+ *
+ * Verified against a pristine tree (2026-08-01): once per-player and
+ * launcher-rewritten files are excluded, `steam_api64.dll` is the **only**
+ * content difference between a vanilla install and a ROTK one. It stays
+ * attested — swapping the shim for a cheat DLL must be caught — but against
+ * the launcher's own artifact rather than the vanilla hash.
+ *
+ * Hashes come from the shipped `resources/patches/*.sha256`, which CI already
+ * checks against a rebuild from source, so there is no third place to keep in
+ * sync. A missing or unreadable sidecar yields no override: the file is then
+ * compared to the vanilla hash and reported as a deviation, which is visible
+ * and safe rather than silently trusted.
+ */
+export async function readLauncherOverrides(
+  overrides: ReadonlyArray<{ installPath: string; bundledPath: string }>,
+): Promise<ManifestFileEntry[]> {
+  const entries: ManifestFileEntry[] = [];
+  for (const { installPath, bundledPath } of overrides) {
+    const digest = await readSidecarSha256(`${bundledPath}.sha256`);
+    if (!digest) continue;
+    const size = await stat(bundledPath).then((info) => info.size).catch(() => null);
+    if (size === null) continue;
+    entries.push({ path: installPath, size, sha256: digest });
+  }
+  return entries;
+}
+
+/** Parses a `<sha256> *<name>` sidecar, the format CI already produces. */
+async function readSidecarSha256(path: string): Promise<string | null> {
+  const raw = await readFile(path, "utf8").catch(() => null);
+  if (raw === null) return null;
+  const digest = raw.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
+  return isSha256Hex(digest) ? digest : null;
+}
+
+export const baseManifestInternals = { CACHE_FILE_NAME, validateManifestUrl };

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -25,6 +25,13 @@ export interface LaunchRequest {
   bundledShimPath: string;
   bundledVivoxProxyPath: string;
   bundledVivoxRuntimePath: string;
+  /**
+   * Integrity attestation hook. Resolves to the block the ticket request
+   * carries, or null when attestation cannot run (no policy published yet, or
+   * the launcher is configured without it). The backend decides what an absent
+   * attestation means — the launcher never self-exempts.
+   */
+  attest?: () => Promise<unknown | null>;
   onExit(exitCode: number | null): void;
 }
 
@@ -174,11 +181,16 @@ export class GameLauncher {
     await mkdir(localLogs, { recursive: true });
     await mkdir(failureLogs, { recursive: true });
 
+    // Integrity attestation runs before the ticket exists: the whole point is
+    // that a tampered installation never obtains one.
+    const attestation = request.attest ? await request.attest() : null;
+
     // The durable website key reaches only the HTTPS account service. H1Z1
     // receives a short ticket and the Steam identity authenticated by it.
     let launchIdentity = await createLaunchTicket(
       request.identity.playerKey,
       request.runtime.launchTicketUrl,
+      { attestation },
     );
     let sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
 
@@ -197,9 +209,13 @@ export class GameLauncher {
         assertLaunchTicketFresh(launchIdentity);
       } catch {
         await sessionGateway.close().catch(() => undefined);
+        // A fresh ticket needs a fresh attestation: the first challenge was
+        // consumed by the request above and is not replayable.
+        const refreshedAttestation = request.attest ? await request.attest() : null;
         launchIdentity = await createLaunchTicket(
           request.identity.playerKey,
           request.runtime.launchTicketUrl,
+          { attestation: refreshedAttestation },
         );
         sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
         await prepareClient(

--- a/electron/services/integrity-attestation.ts
+++ b/electron/services/integrity-attestation.ts
@@ -1,0 +1,420 @@
+/**
+ * Launcher side of integrity attestation.
+ *
+ * Flow per launch:
+ *   1. ask the backend for a signed, single-use challenge (phase A);
+ *   2. verify the challenge signature against the pinned release keys — a
+ *      spoofed backend must not be able to steer what we measure;
+ *   3. measure the installation: hash every file the signed manifests declare,
+ *      report anything missing / altered / unexpected;
+ *   4. return the evidence, which the ticket request carries (phase B).
+ *
+ * Hashing several GB is slow, so `(path, size, mtimeMs) -> sha256` results are
+ * cached in userData. The cache is a UX optimization only: the server never
+ * trusts the client anyway, and a stale entry can only ever cause a *rejection*
+ * (wrong digest), never a false acceptance.
+ */
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import {
+  computeAttestationEvidence,
+  computeManifestRoot,
+  challengeSigningInput,
+  isAttestationExcluded,
+  isManifestPath,
+  isSha256Hex,
+  manifestPathKey,
+  TRUSTED_ATTESTATION_KEYS,
+  verifyAttestationSignature,
+  type ManifestFileEntry,
+  type ObservedDeviation,
+} from "../../shared/attestation.js";
+
+const CACHE_FILE_NAME = "integrity-hash-cache.v1.json";
+const CACHE_SCHEMA_VERSION = 1;
+const MAX_CACHE_ENTRIES = 100_000;
+const MAX_REPORTED_DEVIATIONS = 50;
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface AttestationChallenge {
+  challengeId: string;
+  nonce: string;
+  policyVersion: string;
+  packVersion: string;
+  baseBuildId: string;
+  minLauncherVersion: string;
+  expiresAt: string;
+  keyId: string;
+  signature: string;
+}
+
+export interface AttestationProgress {
+  phase: "challenge" | "measuring" | "done";
+  hashedFiles: number;
+  totalFiles: number;
+  hashedBytes: number;
+  totalBytes: number;
+}
+
+export interface AttestationClaim {
+  policyVersion: string;
+  packVersion: string;
+  baseBuildId: string;
+  launcherVersion: string;
+  fileCount: number;
+  totalBytes: number;
+}
+
+export interface AttestationResult {
+  challengeId: string;
+  evidence: string;
+  claim: AttestationClaim;
+  deviations: ObservedDeviation[];
+}
+
+interface CacheEntry {
+  size: number;
+  mtimeMs: number;
+  sha256: string;
+}
+
+type CacheMap = Map<string, CacheEntry>;
+
+function attestationError(message: string): Error {
+  return new Error(message);
+}
+
+/** Rejects any endpoint that is not a bare HTTPS path, like launch-ticket.ts. */
+function validateEndpoint(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw attestationError("Invalid ROTK attestation endpoint");
+  }
+  if (
+    parsed.protocol !== "https:"
+    || parsed.search !== ""
+    || parsed.hash !== ""
+    || parsed.username !== ""
+    || parsed.password !== ""
+  ) {
+    throw attestationError("Invalid ROTK attestation endpoint");
+  }
+  return parsed.href;
+}
+
+function parseChallenge(
+  payload: unknown,
+  trustedKeys: Readonly<Record<string, string>> = TRUSTED_ATTESTATION_KEYS,
+): AttestationChallenge {
+  if (!payload || typeof payload !== "object") throw attestationError("Invalid attestation challenge");
+  const value = payload as Record<string, unknown>;
+  const strings = [
+    "challengeId", "nonce", "policyVersion", "packVersion",
+    "baseBuildId", "minLauncherVersion", "expiresAt", "keyId", "signature",
+  ] as const;
+  for (const field of strings) {
+    if (typeof value[field] !== "string" || value[field] === "") {
+      throw attestationError("Invalid attestation challenge");
+    }
+  }
+  const challenge = {
+    challengeId: value.challengeId as string,
+    nonce: value.nonce as string,
+    policyVersion: value.policyVersion as string,
+    packVersion: value.packVersion as string,
+    baseBuildId: value.baseBuildId as string,
+    minLauncherVersion: value.minLauncherVersion as string,
+    expiresAt: value.expiresAt as string,
+    keyId: value.keyId as string,
+    signature: value.signature as string,
+  };
+  if (Number.isNaN(Date.parse(challenge.expiresAt))) {
+    throw attestationError("Invalid attestation challenge");
+  }
+  // Signature check before any measurement: this is what makes the challenge
+  // trustworthy enough to act on.
+  const signed = verifyAttestationSignature(
+    challengeSigningInput(challenge),
+    challenge.signature,
+    challenge.keyId,
+    trustedKeys,
+  );
+  if (!signed) {
+    throw attestationError(
+      "The ROTK integrity challenge was not signed by a trusted key. Update the launcher and try again.",
+    );
+  }
+  return challenge;
+}
+
+export async function requestAttestationChallenge(
+  playerKey: string,
+  endpointValue: string,
+  launcherVersion: string,
+  options: {
+    fetchImpl?: typeof fetch;
+    timeoutMs?: number;
+    /** Overridable for tests only; production always uses the pinned table. */
+    trustedKeys?: Readonly<Record<string, string>>;
+  } = {},
+): Promise<AttestationChallenge> {
+  const endpoint = validateEndpoint(endpointValue);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    let response: Response;
+    try {
+      response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ launcherKey: playerKey, launcherVersion }),
+        cache: "no-store",
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch {
+      throw attestationError("Unable to reach the ROTK integrity service");
+    }
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw attestationError("Invalid response from the ROTK integrity service");
+    }
+    if (!response.ok) {
+      const code = payload && typeof payload === "object"
+        ? (payload as Record<string, unknown>).error
+        : null;
+      if (code === "invalid_credentials") throw attestationError("The ROTK launcher key was rejected");
+      if (code === "policy_unavailable") {
+        throw attestationError("ROTK has no published integrity policy yet. Try again later.");
+      }
+      if (code === "rate_limited") {
+        throw attestationError("Too many ROTK integrity checks. Wait a moment and try again");
+      }
+      throw attestationError("The ROTK integrity service is temporarily unavailable");
+    }
+    return parseChallenge(payload, options.trustedKeys ?? TRUSTED_ATTESTATION_KEYS);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function sha256File(path: string): Promise<string> {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("error", rejectPromise);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolvePromise(hash.digest("hex")));
+  });
+}
+
+async function loadCache(userDataDirectory: string): Promise<CacheMap> {
+  try {
+    const raw = JSON.parse(await readFile(join(userDataDirectory, CACHE_FILE_NAME), "utf8")) as unknown;
+    if (!raw || typeof raw !== "object") return new Map();
+    const record = raw as { schemaVersion?: unknown; entries?: unknown };
+    if (record.schemaVersion !== CACHE_SCHEMA_VERSION || !Array.isArray(record.entries)) return new Map();
+    const cache: CacheMap = new Map();
+    for (const entry of record.entries.slice(0, MAX_CACHE_ENTRIES)) {
+      if (!entry || typeof entry !== "object") continue;
+      const { path, size, mtimeMs, sha256 } = entry as Record<string, unknown>;
+      if (typeof path !== "string" || typeof size !== "number" || typeof mtimeMs !== "number") continue;
+      if (!isSha256Hex(sha256)) continue;
+      cache.set(path, { size, mtimeMs, sha256 });
+    }
+    return cache;
+  } catch {
+    return new Map();
+  }
+}
+
+async function saveCache(userDataDirectory: string, cache: CacheMap): Promise<void> {
+  const entries = [...cache.entries()]
+    .slice(0, MAX_CACHE_ENTRIES)
+    .map(([path, entry]) => ({ path, ...entry }));
+  try {
+    await writeFile(
+      join(userDataDirectory, CACHE_FILE_NAME),
+      JSON.stringify({ schemaVersion: CACHE_SCHEMA_VERSION, entries }),
+      { encoding: "utf8", mode: 0o600 },
+    );
+  } catch {
+    // A cache we cannot persist only costs time on the next launch.
+  }
+}
+
+export interface MeasureOptions {
+  installationRoot: string;
+  userDataDirectory: string;
+  /** Expected files, from the signed base manifest merged with asset packs. */
+  expected: readonly ManifestFileEntry[];
+  /** Extra files found on disk that no manifest declares, if known. */
+  unexpectedPaths?: readonly string[];
+  /**
+   * Walk the installation to find files no manifest declares. Off by default:
+   * it costs a full directory traversal, and callers that already know the
+   * extra paths should pass `unexpectedPaths` instead.
+   */
+  detectUnexpected?: boolean;
+  onProgress?(progress: AttestationProgress): void;
+}
+
+/**
+ * Extensions worth reporting when they appear undeclared inside the game tree.
+ *
+ * Deliberately narrow: an undeclared `.txt` next to the exe is noise, an
+ * undeclared `.pack2` or `.dll` is someone shipping content or code into the
+ * game. Excluded paths (per-player settings, logs, BattlEye) never reach here.
+ */
+const UNEXPECTED_EXTENSIONS = new Set([
+  "pack2", "pack", "dll", "exe", "asset", "bundle", "dat", "bin",
+]);
+
+/** Enumerates undeclared files of interest under the installation root. */
+async function findUnexpectedFiles(
+  installationRoot: string,
+  declared: ReadonlySet<string>,
+): Promise<string[]> {
+  const found: string[] = [];
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const absolute = join(directory, entry.name);
+      const relative = installationRelativePath(installationRoot, absolute);
+      if (isAttestationExcluded(relative)) continue;
+      if (entry.isDirectory()) {
+        await walk(absolute);
+        continue;
+      }
+      // Symlinks and specials are skipped: following them could reach outside
+      // the installation, and a pristine tree contains none.
+      if (!entry.isFile()) continue;
+      if (declared.has(manifestPathKey(relative))) continue;
+      const extension = entry.name.split(".").pop()?.toLowerCase() ?? "";
+      if (!UNEXPECTED_EXTENSIONS.has(extension)) continue;
+      found.push(relative);
+      if (found.length >= MAX_REPORTED_DEVIATIONS) return;
+    }
+  };
+  await walk(installationRoot);
+  return found;
+}
+
+export interface Measurement {
+  root: string;
+  fileCount: number;
+  totalBytes: number;
+  deviations: ObservedDeviation[];
+}
+
+/**
+ * Hashes the declared installation and derives its canonical root.
+ *
+ * A file that is missing or altered is reported as a deviation AND folded into
+ * the root as observed, so the server sees both the self-report and a digest
+ * that cannot match the expected one.
+ */
+export async function measureInstallation(options: MeasureOptions): Promise<Measurement> {
+  const { installationRoot, userDataDirectory, expected, onProgress } = options;
+  const cache = await loadCache(userDataDirectory);
+  const nextCache: CacheMap = new Map();
+  const deviations: ObservedDeviation[] = [];
+  const observed: ManifestFileEntry[] = [];
+  const totalBytes = expected.reduce((sum, entry) => sum + entry.size, 0);
+  let hashedFiles = 0;
+  let hashedBytes = 0;
+
+  onProgress?.({ phase: "measuring", hashedFiles: 0, totalFiles: expected.length, hashedBytes: 0, totalBytes });
+
+  for (const entry of expected) {
+    if (!isManifestPath(entry.path)) throw attestationError("The integrity manifest contains an invalid path.");
+    const absolute = join(installationRoot, ...entry.path.split("/"));
+    const fileStat = await stat(absolute).catch(() => null);
+    if (!fileStat?.isFile()) {
+      deviations.push({ path: entry.path, kind: "missing", observedSha256: null });
+      hashedFiles += 1;
+      continue;
+    }
+    const cacheKey = manifestPathKey(entry.path);
+    const cached = cache.get(cacheKey);
+    const digest = cached && cached.size === fileStat.size && cached.mtimeMs === fileStat.mtimeMs
+      ? cached.sha256
+      : await sha256File(absolute);
+    nextCache.set(cacheKey, { size: fileStat.size, mtimeMs: fileStat.mtimeMs, sha256: digest });
+    observed.push({ path: entry.path, size: fileStat.size, sha256: digest });
+    if (digest !== entry.sha256) {
+      deviations.push({ path: entry.path, kind: "mismatch", observedSha256: digest });
+    }
+    hashedFiles += 1;
+    hashedBytes += fileStat.size;
+    if (hashedFiles % 50 === 0) {
+      onProgress?.({ phase: "measuring", hashedFiles, totalFiles: expected.length, hashedBytes, totalBytes });
+    }
+  }
+
+  const unexpected = options.detectUnexpected
+    ? await findUnexpectedFiles(installationRoot, new Set(expected.map((entry) => manifestPathKey(entry.path))))
+    : (options.unexpectedPaths ?? []);
+  for (const path of unexpected) {
+    if (!isManifestPath(path)) continue;
+    const absolute = join(installationRoot, ...path.split("/"));
+    const digest = await sha256File(absolute).catch(() => null);
+    deviations.push({ path, kind: "unexpected", observedSha256: digest });
+    if (digest) {
+      const fileStat = await stat(absolute).catch(() => null);
+      observed.push({ path, size: fileStat?.size ?? 0, sha256: digest });
+    }
+  }
+
+  await saveCache(userDataDirectory, nextCache);
+  onProgress?.({ phase: "done", hashedFiles, totalFiles: expected.length, hashedBytes, totalBytes });
+
+  return {
+    root: computeManifestRoot(observed),
+    fileCount: observed.length,
+    totalBytes: observed.reduce((sum, entry) => sum + entry.size, 0),
+    deviations: deviations.slice(0, MAX_REPORTED_DEVIATIONS),
+  };
+}
+
+/** Binds a measurement to a challenge, producing the block the ticket carries. */
+export function buildAttestationResult(
+  challenge: AttestationChallenge,
+  measurement: Measurement,
+  launcherVersion: string,
+): AttestationResult {
+  return {
+    challengeId: challenge.challengeId,
+    evidence: computeAttestationEvidence(challenge.nonce, measurement.root),
+    claim: {
+      policyVersion: challenge.policyVersion,
+      packVersion: challenge.packVersion,
+      baseBuildId: challenge.baseBuildId,
+      launcherVersion,
+      fileCount: measurement.fileCount,
+      totalBytes: measurement.totalBytes,
+    },
+    deviations: measurement.deviations,
+  };
+}
+
+/** Relative, `/`-separated path of an absolute file inside the installation. */
+export function installationRelativePath(installationRoot: string, absolutePath: string): string {
+  return relative(installationRoot, absolutePath).split(sep).join("/");
+}
+
+export const integrityAttestationInternals = {
+  parseChallenge,
+  validateEndpoint,
+  loadCache,
+  saveCache,
+  CACHE_FILE_NAME,
+};

--- a/electron/services/launch-ticket.ts
+++ b/electron/services/launch-ticket.ts
@@ -26,6 +26,11 @@ export interface LaunchTicketIdentity {
 interface TicketRequestOptions {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
+  /**
+   * Integrity attestation block (see integrity-attestation.ts). Optional while
+   * the backend runs in observation mode; required once enforcement is on.
+   */
+  attestation?: unknown;
 }
 
 function validateEndpoint(value: string): URL {
@@ -140,9 +145,25 @@ function parseTicketResponse(
   return identity;
 }
 function serviceError(status: number, value: unknown): Error {
-  const errorCode = value && typeof value === "object"
-    ? (value as Record<string, unknown>).error
-    : null;
+  const payload = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  const errorCode = payload?.error ?? null;
+  if (errorCode === "attestation_failed") {
+    return new Error(
+      "The game files do not match the official ROTK installation. Use Verify files, then try again.",
+    );
+  }
+  if (errorCode === "launcher_update_required") {
+    return new Error("This launcher version is too old to verify the game files. Update the launcher.");
+  }
+  if (errorCode === "account_banned") {
+    const expiresAt = typeof payload?.expiresAt === "string" ? payload.expiresAt : null;
+    const reason = typeof payload?.reason === "string" && payload.reason ? ` Reason: ${payload.reason}` : "";
+    return new Error(
+      expiresAt
+        ? `This ROTK account is suspended until ${new Date(expiresAt).toLocaleString()}.${reason}`
+        : `This ROTK account is permanently banned.${reason}`,
+    );
+  }
   if (status === 401 || errorCode === "invalid_credentials") {
     return new Error("The ROTK launcher key was rejected");
   }
@@ -176,7 +197,10 @@ export async function createLaunchTicket(
           Accept: "application/json",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ launcherKey: normalizePlayerKey(playerKey) }),
+        body: JSON.stringify({
+          launcherKey: normalizePlayerKey(playerKey),
+          ...(options.attestation ? { attestation: options.attestation } : {}),
+        }),
         cache: "no-store",
         redirect: "error",
         signal: controller.signal,

--- a/electron/services/runtime-config.ts
+++ b/electron/services/runtime-config.ts
@@ -8,6 +8,8 @@ export interface RuntimeConfig {
   loginPorts: number[];
   websiteOrigin: string;
   launchTicketUrl: string;
+  /** Phase A of integrity attestation: issues the signed single-use challenge. */
+  attestationChallengeUrl: string;
 }
 
 /**
@@ -24,6 +26,8 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   loginPorts: [20042, 20043, 20044, 20045],
   websiteOrigin: "https://rotk.app",
   launchTicketUrl: "https://europe-west1-rotk-project.cloudfunctions.net/createLaunchTicket",
+  attestationChallengeUrl:
+    "https://europe-west1-rotk-project.cloudfunctions.net/beginLauncherAttestation",
 };
 
 export function serverList(runtime: RuntimeConfig): string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/scripts/generate-attestation-keypair.mjs
+++ b/scripts/generate-attestation-keypair.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Generates an Ed25519 release key pair for launcher attestation.
+ *
+ * The private seed signs manifests, policies and challenges; it belongs in GCP
+ * Secret Manager (never a repo). The public key is printed for pasting into
+ * TRUSTED_ATTESTATION_KEYS in shared/attestation.ts — it is not a secret and is
+ * expected to live in the open-source launcher.
+ *
+ * Rotation: run again with a fresh --key-id, add the public key alongside the
+ * old one, ship the launcher, then switch the signing secret. Remove the old
+ * entry in a later release to revoke it.
+ *
+ * Usage: node scripts/generate-attestation-keypair.mjs --key-id rotk-attest-2026-08
+ */
+
+import { generateKeyPairSync } from "node:crypto";
+
+const args = process.argv.slice(2);
+const keyIdIndex = args.indexOf("--key-id");
+const keyId = keyIdIndex >= 0 ? args[keyIdIndex + 1] : "";
+
+if (!/^[a-z0-9][a-z0-9-]{2,63}$/.test(keyId ?? "")) {
+  console.error("Usage: node scripts/generate-attestation-keypair.mjs --key-id <lowercase-id>");
+  process.exit(2);
+}
+
+const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+const pkcs8 = privateKey.export({ format: "der", type: "pkcs8" });
+const spki = publicKey.export({ format: "der", type: "spki" });
+// Raw 32-byte seed / public key are the last 32 bytes of the DER encodings.
+const seedBase64Url = pkcs8.subarray(pkcs8.length - 32).toString("base64url");
+const publicBase64Url = spki.subarray(spki.length - 32).toString("base64url");
+
+console.log(`keyId: ${keyId}`);
+console.log("");
+console.log("--- PUBLIC KEY (commit this) ---");
+console.log("In rotk-launcher/shared/attestation.ts, TRUSTED_ATTESTATION_KEYS:");
+console.log(`  "${keyId}": "${publicBase64Url}",`);
+console.log("");
+console.log("--- PRIVATE SEED (never commit) ---");
+console.log("Store in Secret Manager as ROTK_ATTEST_SIGNING_SEED:");
+console.log(`  ${seedBase64Url}`);
+console.log("");
+console.log("  printf '%s' '<seed>' | gcloud secrets create ROTK_ATTEST_SIGNING_SEED \\");
+console.log("    --project rotk-project --data-file=-");
+console.log("");
+console.log("Also record the keyId as ROTK_ATTEST_SIGNING_KEY_ID.");

--- a/scripts/generate-base-manifest.mjs
+++ b/scripts/generate-base-manifest.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Builds the signed BASE_MANIFEST for a pristine H1Z1 installation.
+ *
+ * The manifest enumerates every file of the untouched game tree with its
+ * sha256, and carries the canonical root the server stores as `expectedRoot`.
+ * Run it once per supported client build, from a Steam-verified installation
+ * that the launcher has never patched.
+ *
+ * Excluded by design (the launcher rewrites these on every launch, so they can
+ * never be part of a stable root): see EXCLUDED_PATHS below.
+ *
+ * Usage:
+ *   node scripts/generate-base-manifest.mjs \
+ *     --source "D:/Steam/steamapps/common/H1Z1" \
+ *     --build-id 1.0.326.439939 \
+ *     --out out/base-manifest.v1.json \
+ *     [--sign-seed <base64url> --key-id rotk-attest-2026-08]
+ *
+ * Without --sign-seed the manifest is written unsigned (for inspection); the
+ * release pipeline signs it with the Secret Manager seed.
+ */
+
+import { createHash, sign as signPayload } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+const MANIFEST_ROOT_DOMAIN = "rotk-manifest-v1";
+const MANIFEST_SIGNATURE_DOMAIN = "rotk-manifest-sig-v1";
+const SCHEMA_VERSION = 1;
+
+/**
+ * MIRROR of ATTESTATION_EXCLUDED_* in shared/attestation.ts (a standalone
+ * script cannot import the TS module). Keep them identical — a divergence
+ * makes the launcher and the server disagree on the expected root and rejects
+ * every honest player. Inclusion criteria and rationale live in that module.
+ */
+const EXCLUDED_PATHS = new Set([
+  // Per-player, rewritten by the game itself.
+  "useroptions.ini",
+  "inputprofile_user.xml",
+  // Rewritten by the launcher before every launch.
+  "clientconfig.ini",
+  "battleye/beclient_x64.cfg",
+  "steam_persona_name.txt",
+  // Launcher bookkeeping and vanilla backups.
+  ".rotk-installation.json",
+  "clientconfig.original.ini",
+  "battleye/beclient_x64.cfg.original",
+  "steam_api64.original.dll",
+]);
+const EXCLUDED_PREFIXES = ["logs/", "crashes/", "cache/", "battleye/"];
+const EXCLUDED_SUFFIXES = [".log", ".dmp", ".original"];
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    if (!argv[index]?.startsWith("--")) continue;
+    args.set(argv[index].slice(2), argv[index + 1] ?? "");
+  }
+  return args;
+}
+
+function isExcluded(relativePath) {
+  const lower = relativePath.toLowerCase();
+  if (EXCLUDED_PATHS.has(lower)) return true;
+  if (EXCLUDED_PREFIXES.some((prefix) => lower.startsWith(prefix))) return true;
+  return EXCLUDED_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+async function* walk(root, current = root) {
+  const entries = await readdir(current, { withFileTypes: true });
+  for (const entry of entries.sort((left, right) => (left.name < right.name ? -1 : 1))) {
+    const absolute = join(current, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(root, absolute);
+    } else if (entry.isFile()) {
+      yield absolute;
+    }
+    // Symlinks and specials are skipped: a pristine Steam tree has none, and
+    // following them could hash files outside the installation.
+  }
+}
+
+function sha256File(path) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(path);
+    stream.on("error", rejectPromise);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolvePromise(hash.digest("hex")));
+  });
+}
+
+function computeManifestRoot(entries) {
+  const hash = createHash("sha256");
+  hash.update(`${MANIFEST_ROOT_DOMAIN}\0`, "utf8");
+  const sorted = [...entries].sort((left, right) => {
+    const leftKey = left.path.toLowerCase();
+    const rightKey = right.path.toLowerCase();
+    if (leftKey < rightKey) return -1;
+    if (leftKey > rightKey) return 1;
+    return 0;
+  });
+  for (const entry of sorted) {
+    hash.update(`${entry.path}\0${entry.sha256}\n`, "utf8");
+  }
+  return hash.digest("hex");
+}
+
+function ed25519PrivateKeyDer(seedBase64Url) {
+  const raw = Buffer.from(seedBase64Url, "base64url");
+  if (raw.length !== 32) throw new Error("The signing seed must decode to 32 bytes.");
+  return Buffer.concat([Buffer.from("302e020100300506032b657004220420", "hex"), raw]);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const source = args.get("source");
+  const buildId = args.get("build-id");
+  const outPath = args.get("out") ?? "out/base-manifest.v1.json";
+  const signSeed = args.get("sign-seed") ?? "";
+  const keyId = args.get("key-id") ?? "";
+
+  if (!source || !buildId) {
+    console.error("Usage: node scripts/generate-base-manifest.mjs --source <game dir> --build-id <id> [--out <file>] [--sign-seed <seed> --key-id <id>]");
+    process.exit(2);
+  }
+  if (Boolean(signSeed) !== Boolean(keyId)) {
+    console.error("--sign-seed and --key-id must be provided together.");
+    process.exit(2);
+  }
+
+  const root = resolve(source);
+  const rootStat = await stat(root).catch(() => null);
+  if (!rootStat?.isDirectory()) {
+    console.error(`Not a directory: ${root}`);
+    process.exit(2);
+  }
+
+  const files = [];
+  let totalBytes = 0;
+  let excludedCount = 0;
+  for await (const absolute of walk(root)) {
+    const relativePath = relative(root, absolute).split(sep).join("/");
+    if (isExcluded(relativePath)) {
+      excludedCount += 1;
+      continue;
+    }
+    const fileStat = await stat(absolute);
+    const sha256 = await sha256File(absolute);
+    files.push({ path: relativePath, size: fileStat.size, sha256 });
+    totalBytes += fileStat.size;
+    if (files.length % 500 === 0) process.stderr.write(`  hashed ${files.length} files\r`);
+  }
+
+  const seen = new Set();
+  for (const entry of files) {
+    const key = entry.path.toLowerCase();
+    if (seen.has(key)) throw new Error(`Duplicate path after normalization: ${entry.path}`);
+    seen.add(key);
+  }
+
+  const manifestRoot = computeManifestRoot(files);
+  const issuedAt = new Date().toISOString();
+  const manifest = {
+    schemaVersion: SCHEMA_VERSION,
+    kind: "base-game",
+    buildId,
+    root: manifestRoot,
+    fileCount: files.length,
+    totalBytes,
+    issuedAt,
+    files,
+    ...(keyId ? { keyId } : {}),
+  };
+
+  if (signSeed) {
+    const signingInput = [
+      MANIFEST_SIGNATURE_DOMAIN,
+      "base-game",
+      String(SCHEMA_VERSION),
+      buildId,
+      manifestRoot,
+      issuedAt,
+      "",
+    ].join("\0");
+    manifest.signature = signPayload(
+      null,
+      Buffer.from(signingInput, "utf8"),
+      { key: ed25519PrivateKeyDer(signSeed), format: "der", type: "pkcs8" },
+    ).toString("base64url");
+  }
+
+  await mkdir(dirname(resolve(outPath)), { recursive: true });
+  await writeFile(resolve(outPath), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  console.log("");
+  console.log(`build      : ${buildId}`);
+  console.log(`files      : ${files.length} (${excludedCount} excluded)`);
+  console.log(`total      : ${(totalBytes / 1024 ** 3).toFixed(2)} GB`);
+  console.log(`root       : ${manifestRoot}`);
+  console.log(`signature  : ${manifest.signature ? `present (${keyId})` : "ABSENT — unsigned manifest"}`);
+  console.log(`written    : ${resolve(outPath)}`);
+  console.log("");
+  console.log("Store this root as expectedRoot when publishing the attestation policy.");
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exit(1);
+});

--- a/scripts/package-asset-packs.ps1
+++ b/scripts/package-asset-packs.ps1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+Packages game asset files into one zip per file and emits the matching
+feed.json for the h1z1rotk/assets repository.
+
+.DESCRIPTION
+Each input file becomes its own release payload so launcher updates only
+re-download the packs that actually changed (the launcher diffs by sha256).
+Archives are written with the .NET ZipArchive API, which stays on the classic
+zip format for entries below 4 GiB - the launcher zip reader rejects Zip64.
+
+.EXAMPLE
+./scripts/package-asset-packs.ps1 `
+  -SourceDirectory ../assets/assets `
+  -OutputDirectory ./out/asset-release `
+  -PackVersion 1.1.0
+Then create the GitHub release (tag printed at the end), upload the zips and
+commit the generated feed.json to h1z1rotk/assets main.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$SourceDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string]$OutputDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [ValidatePattern('^\d+\.\d+\.\d+$')]
+  [string]$PackVersion,
+
+  # Directory inside the game installation where the packs are extracted.
+  [string]$InstallPath = "Resources/Assets",
+
+  [string]$ReleaseTag = "",
+
+  [string]$RepositorySlug = "h1z1rotk/assets"
+)
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+if ($ReleaseTag -eq "") { $ReleaseTag = "assets-v$PackVersion" }
+
+# Windows PowerShell's Out-File -Encoding utf8 emits a BOM, and JSON.parse
+# rejects a leading BOM: the launcher would refuse the feed outright.
+function Write-JsonNoBom {
+  param([string]$Path, $Value)
+  $json = $Value | ConvertTo-Json -Depth 5
+  [System.IO.File]::WriteAllText($Path, $json, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+$source = Resolve-Path $SourceDirectory
+$files = Get-ChildItem -Path $source -File | Sort-Object Name
+if ($files.Count -eq 0) { throw "No files found in $source." }
+if ($files.Count -gt 64) { throw "The launcher accepts at most 64 assets per feed." }
+
+$maxEntryBytes = 3GB
+foreach ($file in $files) {
+  if ($file.Length -gt $maxEntryBytes) {
+    throw "$($file.Name) is $([math]::Round($file.Length / 1GB, 2)) GB - above the launcher per-asset cap (3 GB)."
+  }
+  if ($file.Extension -match '^\.(exe|dll|sys|bat|cmd|ps1|msi|scr|com|vbs|lnk)$') {
+    throw "$($file.Name) has a blocked extension - executable content ships in the signed launcher, never in the feed."
+  }
+}
+
+New-Item -ItemType Directory -Force $OutputDirectory | Out-Null
+$output = Resolve-Path $OutputDirectory
+
+$assets = @()
+$payloads = @()
+$totalUncompressed = 0
+foreach ($file in $files) {
+  $baseName = [System.IO.Path]::GetFileNameWithoutExtension($file.Name)
+  $zipName = "$baseName.zip"
+  $zipPath = Join-Path $output $zipName
+  if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
+
+  Write-Host "Compressing $($file.Name) ($([math]::Round($file.Length / 1MB, 1)) MB)..."
+  $archive = [System.IO.Compression.ZipFile]::Open($zipPath, [System.IO.Compression.ZipArchiveMode]::Create)
+  try {
+    [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+      $archive, $file.FullName, $file.Name,
+      [System.IO.Compression.CompressionLevel]::Optimal) | Out-Null
+  } finally {
+    $archive.Dispose()
+  }
+
+  $zipItem = Get-Item $zipPath
+  $hash = (Get-FileHash -Algorithm SHA256 $zipPath).Hash.ToLowerInvariant()
+  $totalUncompressed += $file.Length
+
+  # Hash of the file as it lands in the game install (uncompressed), used by
+  # the server to fold asset payloads into the attestation expectedRoot. This
+  # is the same value the launcher records in asset-state.v1.json, so both
+  # sides derive the same root.
+  $payloads += [ordered]@{
+    path   = "$InstallPath/$($file.Name)"
+    size   = $file.Length
+    sha256 = (Get-FileHash -Algorithm SHA256 $file.FullName).Hash.ToLowerInvariant()
+  }
+
+  $assets += [ordered]@{
+    name        = $baseName.ToLowerInvariant()
+    version     = $PackVersion
+    url         = "https://github.com/$RepositorySlug/releases/download/$ReleaseTag/$zipName"
+    sha256      = $hash
+    size        = $zipItem.Length
+    installPath = $InstallPath
+    type        = "zip"
+  }
+  Write-Host "  -> $zipName : $([math]::Round($zipItem.Length / 1MB, 1)) MB, sha256 $hash"
+}
+
+if ($totalUncompressed -gt 8GB) {
+  throw "Uncompressed payload total exceeds the launcher 8 GB cap."
+}
+
+$feed = [ordered]@{
+  manifestVersion = 1
+  packVersion     = $PackVersion
+  assets          = $assets
+}
+$feedPath = Join-Path $output "feed.json"
+Write-JsonNoBom -Path $feedPath -Value $feed
+
+# Consumed by rotk-web/scripts/publish-attestation-policy.mjs so the server's
+# expectedRoot covers the asset files, not just the base game tree.
+$payloadManifest = [ordered]@{
+  schemaVersion = 1
+  kind          = "asset-payloads"
+  packVersion   = $PackVersion
+  files         = $payloads
+}
+$payloadPath = Join-Path $output "asset-payloads.v1.json"
+Write-JsonNoBom -Path $payloadPath -Value $payloadManifest
+
+Write-Host ""
+Write-Host "Wrote $($assets.Count) payload(s), feed.json and asset-payloads.v1.json to $output"
+Write-Host "Next steps:"
+Write-Host "  1. Create release '$ReleaseTag' on $RepositorySlug and attach the zips."
+Write-Host "  2. Commit the generated feed.json to $RepositorySlug main."
+Write-Host "  3. Pass asset-payloads.v1.json to publish-attestation-policy.mjs --asset-payloads."

--- a/shared/attestation.ts
+++ b/shared/attestation.ts
@@ -1,0 +1,336 @@
+/**
+ * Launcher integrity attestation — canonical encodings and signature verification.
+ *
+ * The launcher is open source and runs on the player's machine, so nothing here
+ * is a secret. What the protocol buys us is:
+ *
+ *  - replay resistance: every attestation answers a fresh single-use server nonce;
+ *  - manifest authenticity: manifests are Ed25519-signed by the ROTK release key,
+ *    so a hostile mirror cannot redefine what "unmodified files" means;
+ *  - a server-side verdict: the server compares the evidence against its own
+ *    expected root, so recompiling the launcher to claim success achieves nothing.
+ *
+ * What it cannot buy (client-side hashing on hostile hardware): a determined
+ * attacker may keep pristine copies and hash those while the game loads modified
+ * files. See docs/SPEC_LAUNCHER_ATTESTATION.md §2.
+ *
+ * IMPORTANT: the canonical encodings below are mirrored byte-for-byte by the
+ * backend module `rotk-web/functions/attestation.js`. The shared test vectors in
+ * ATTESTATION_TEST_VECTORS must produce identical digests on both sides — any
+ * change here is a protocol break requiring a coordinated release.
+ */
+
+import { createHash, verify as verifySignature } from "node:crypto";
+
+export const ATTESTATION_PROTOCOL_VERSION = 1;
+
+/** Domain separation tags. Never reuse a digest across contexts. */
+export const MANIFEST_ROOT_DOMAIN = "rotk-manifest-v1";
+export const EVIDENCE_DOMAIN = "rotk-attest-v1";
+export const CHALLENGE_DOMAIN = "rotk-challenge-v1";
+export const MANIFEST_SIGNATURE_DOMAIN = "rotk-manifest-sig-v1";
+
+/**
+ * Ed25519 public keys trusted to sign manifests and challenges, by keyId.
+ * Rotation: add the new keyId here, ship the launcher, then start signing with
+ * it. Revocation: remove the entry and ship again.
+ *
+ * Values are raw 32-byte Ed25519 public keys, base64url, no padding.
+ */
+export const TRUSTED_ATTESTATION_KEYS: Readonly<Record<string, string>> = Object.freeze({
+  // Generated 2026-08-01 by scripts/generate-attestation-keypair.mjs.
+  // Public keys are not secrets: this launcher is open source by design.
+  // Rotation: add the new keyId, ship, switch the signing secret, then drop the
+  // old entry in a later release to revoke it.
+  "rotk-attest-2026-08": "1wcGNjmHAzinYVM0WbUzyGmIcv67nSTPfLTunS_Rv-4",
+});
+
+/**
+ * Files excluded from the attestation root, lowercased, `/`-separated.
+ *
+ * MIRROR NOTICE: this list is duplicated in
+ * `rotk-launcher/scripts/generate-base-manifest.mjs` and
+ * `rotk-web/scripts/publish-attestation-policy.mjs` (standalone scripts that
+ * cannot import this module). A divergence makes the launcher and the server
+ * disagree on the expected root, rejecting every honest player. Both web tests
+ * and launcher tests assert the lists match.
+ *
+ * Inclusion criteria — a path belongs here ONLY if:
+ *   1. it legitimately differs between two honest installations (per-player
+ *      settings, keybinds), or is rewritten on every launch by the launcher; AND
+ *   2. it cannot carry gameplay content or executable code.
+ *
+ * No `.pack2`, no `.dll`, no `.exe` may ever be added here: those are exactly
+ * what attestation exists to protect. `steam_api64.dll` is NOT excluded — the
+ * launcher replaces it with its own shim, so it is verified against the shim
+ * hash instead (see ATTESTATION_OVERRIDE_PATHS).
+ *
+ * Verified against a real installation (2026-08-01): the game rewrites
+ * `UserOptions.ini` (graphics/audio/sensitivity) and `InputProfile_User.xml`
+ * (keybinds) on every session, and both differ per player.
+ */
+export const ATTESTATION_EXCLUDED_PATHS: ReadonlySet<string> = new Set([
+  // Per-player, rewritten by the game itself.
+  "useroptions.ini",
+  "inputprofile_user.xml",
+  // Rewritten by the launcher before every launch.
+  "clientconfig.ini",
+  "battleye/beclient_x64.cfg",
+  "steam_persona_name.txt",
+  // Launcher bookkeeping and vanilla backups (absent from a pristine tree).
+  ".rotk-installation.json",
+  "clientconfig.original.ini",
+  "battleye/beclient_x64.cfg.original",
+  "steam_api64.original.dll",
+]);
+
+/** Directory prefixes never part of the shipped tree (runtime output). */
+export const ATTESTATION_EXCLUDED_PREFIXES: readonly string[] = [
+  "logs/",
+  "crashes/",
+  "cache/",
+  // BattlEye updates its own client binaries out of band; attesting them would
+  // reject players mid-update. Deliberate gap — BattlEye guards itself.
+  "battleye/",
+];
+
+/** Filename suffixes never part of the shipped tree. */
+export const ATTESTATION_EXCLUDED_SUFFIXES: readonly string[] = [
+  ".log",
+  ".dmp",
+  ".original",
+];
+
+/**
+ * Files the launcher deliberately replaces: expected content is the launcher's
+ * own artifact, not the vanilla one. They stay attested (they are executable
+ * code — the highest-value target) but against the replacement hash, which the
+ * release pipeline supplies from `resources/patches/*.sha256`.
+ */
+export const ATTESTATION_OVERRIDE_PATHS: readonly string[] = [
+  "steam_api64.dll",
+  "vivoxsdk_x64.dll",
+];
+
+/** True when a path must not take part in the attestation root. */
+export function isAttestationExcluded(path: string): boolean {
+  const lower = path.toLowerCase();
+  if (ATTESTATION_EXCLUDED_PATHS.has(lower)) return true;
+  if (ATTESTATION_EXCLUDED_PREFIXES.some((prefix) => lower.startsWith(prefix))) return true;
+  return ATTESTATION_EXCLUDED_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
+export type ManifestFileEntry = {
+  /** Relative to the game installation root, `/`-separated, case preserved. */
+  path: string;
+  size: number;
+  sha256: string;
+};
+
+export type DeviationKind = "missing" | "mismatch" | "unexpected";
+
+export type ObservedDeviation = {
+  path: string;
+  kind: DeviationKind;
+  observedSha256: string | null;
+};
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+/** Conservative path shape: no drive letters, no `..`, no backslashes. */
+const MANIFEST_PATH = /^(?!\/)(?!.*\/\/)(?!.*(?:^|\/)\.\.(?:\/|$))[^\\:*?"<>|\r\n]+$/;
+
+export class AttestationFormatError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "AttestationFormatError";
+    this.code = code;
+  }
+}
+
+function fail(code: string, message: string): never {
+  throw new AttestationFormatError(code, message);
+}
+
+export function isSha256Hex(value: unknown): value is string {
+  return typeof value === "string" && HEX64.test(value);
+}
+
+export function isManifestPath(value: unknown): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= 512
+    && MANIFEST_PATH.test(value);
+}
+
+/**
+ * Canonical path key for ordering and duplicate detection.
+ *
+ * Windows paths are case-insensitive, so two entries differing only in case
+ * would denote the same file. Ordering uses this key with a plain code-unit
+ * comparison (NOT localeCompare, which is locale-dependent and would produce
+ * different roots on different machines).
+ */
+export function manifestPathKey(path: string): string {
+  return path.toLowerCase();
+}
+
+function compareEntries(left: ManifestFileEntry, right: ManifestFileEntry): number {
+  const leftKey = manifestPathKey(left.path);
+  const rightKey = manifestPathKey(right.path);
+  if (leftKey < rightKey) return -1;
+  if (leftKey > rightKey) return 1;
+  return 0;
+}
+
+/**
+ * Canonical manifest root.
+ *
+ * root = SHA-256( "rotk-manifest-v1\0" || for each entry sorted by lowercased
+ *                 path: path "\0" sha256 "\n" )
+ *
+ * The lowercased path is used only for ordering; the digest consumes the path
+ * as declared, so a case change is a manifest change (and therefore a
+ * deliberate release, not a silent drift).
+ */
+export function computeManifestRoot(entries: readonly ManifestFileEntry[]): string {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (!isManifestPath(entry.path)) fail("invalid-path", `Invalid manifest path: ${String(entry.path).slice(0, 80)}`);
+    if (!isSha256Hex(entry.sha256)) fail("invalid-sha256", `Invalid sha256 for ${entry.path}`);
+    if (!Number.isSafeInteger(entry.size) || entry.size < 0) fail("invalid-size", `Invalid size for ${entry.path}`);
+    const key = manifestPathKey(entry.path);
+    if (seen.has(key)) fail("duplicate-path", `Duplicate manifest path: ${entry.path}`);
+    seen.add(key);
+  }
+  const hash = createHash("sha256");
+  hash.update(`${MANIFEST_ROOT_DOMAIN}\0`, "utf8");
+  for (const entry of [...entries].sort(compareEntries)) {
+    hash.update(`${entry.path}\0${entry.sha256}\n`, "utf8");
+  }
+  return hash.digest("hex");
+}
+
+/**
+ * Evidence bound to a server nonce.
+ *
+ * evidence = SHA-256( "rotk-attest-v1\0" || nonce(base64url, as received) ||
+ *                     "\0" || root(hex) )
+ *
+ * The nonce is consumed as the exact ASCII the server sent, so both sides agree
+ * without needing a shared base64 decoder convention.
+ */
+export function computeAttestationEvidence(nonce: string, root: string): string {
+  if (typeof nonce !== "string" || nonce.length < 16 || nonce.length > 128 || !BASE64URL.test(nonce)) {
+    fail("invalid-nonce", "The attestation nonce is malformed.");
+  }
+  if (!isSha256Hex(root)) fail("invalid-root", "The manifest root is malformed.");
+  return createHash("sha256")
+    .update(`${EVIDENCE_DOMAIN}\0${nonce}\0${root}`, "utf8")
+    .digest("hex");
+}
+
+/**
+ * Bytes the server signs when issuing a challenge. The launcher verifies this
+ * before hashing anything, so a spoofed backend cannot steer the computation.
+ */
+export function challengeSigningInput(challenge: {
+  challengeId: string;
+  nonce: string;
+  policyVersion: string;
+  expiresAt: string;
+}): string {
+  return [
+    CHALLENGE_DOMAIN,
+    challenge.challengeId,
+    challenge.nonce,
+    challenge.policyVersion,
+    challenge.expiresAt,
+  ].join("\0");
+}
+
+/**
+ * Bytes the release tooling signs for a manifest or policy document. Only
+ * identity-bearing fields participate: the document is reconstructed from them,
+ * so no JSON canonicalization is needed.
+ */
+export function manifestSigningInput(document: {
+  kind: string;
+  schemaVersion: number;
+  version: string;
+  root: string;
+  issuedAt: string;
+  expiresAt?: string | null;
+}): string {
+  return [
+    MANIFEST_SIGNATURE_DOMAIN,
+    document.kind,
+    String(document.schemaVersion),
+    document.version,
+    document.root,
+    document.issuedAt,
+    document.expiresAt ?? "",
+  ].join("\0");
+}
+
+function ed25519PublicKeyDer(rawBase64Url: string): Buffer {
+  const raw = Buffer.from(rawBase64Url, "base64url");
+  if (raw.length !== 32) fail("invalid-public-key", "An Ed25519 public key must be 32 bytes.");
+  // SubjectPublicKeyInfo prefix for Ed25519 (RFC 8410).
+  return Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    raw,
+  ]);
+}
+
+/**
+ * Verifies an Ed25519 signature made by a trusted release key.
+ *
+ * Returns false — never throws — on any malformed input, unknown keyId or bad
+ * signature, so callers fail closed with a single check.
+ */
+export function verifyAttestationSignature(
+  signingInput: string,
+  signatureBase64Url: unknown,
+  keyId: unknown,
+  trustedKeys: Readonly<Record<string, string>> = TRUSTED_ATTESTATION_KEYS,
+): boolean {
+  if (typeof keyId !== "string" || !Object.prototype.hasOwnProperty.call(trustedKeys, keyId)) return false;
+  if (typeof signatureBase64Url !== "string" || !BASE64URL.test(signatureBase64Url)) return false;
+  const signature = Buffer.from(signatureBase64Url, "base64url");
+  if (signature.length !== 64) return false;
+  try {
+    return verifySignature(
+      null,
+      Buffer.from(signingInput, "utf8"),
+      { key: ed25519PublicKeyDer(trustedKeys[keyId]), format: "der", type: "spki" },
+      signature,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Frozen cross-implementation test vectors. Both the launcher (vitest) and the
+ * backend (node:test) assert against these; a mismatch means the launcher and
+ * server would disagree on what an unmodified installation hashes to.
+ */
+export const ATTESTATION_TEST_VECTORS = Object.freeze({
+  manifestRoot: Object.freeze({
+    entries: Object.freeze([
+      // Deliberately unsorted, mixed case, to pin the ordering rule.
+      { path: "Resources/Assets/assets_x64_1.pack2", size: 2, sha256: "b".repeat(64) },
+      { path: "H1Z1.exe", size: 3, sha256: "c".repeat(64) },
+      { path: "Resources/Assets/Assets_x64_0.pack2", size: 1, sha256: "a".repeat(64) },
+    ]),
+    expectedRoot: "09e1c2c3aa522584c69b4eaa768c7d09a7f8a3467fa1359eae8482875c849a1c",
+  }),
+  evidence: Object.freeze({
+    nonce: "dGVzdC1ub25jZS0xMjM0NTY3ODkw",
+    root: "d".repeat(64),
+    expectedEvidence: "fc8d2b2e1a15771ff1956aad1f2fa473afeb91d056c059c5c20bc370d918f8a2",
+  }),
+});

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -100,6 +100,17 @@ export interface LauncherUpdateSummary {
   error: string | null;
 }
 
+/**
+ * Progress of the pre-launch integrity check. Null when idle; hashing the whole
+ * installation takes minutes on a first run and seconds afterwards (cached).
+ */
+export interface IntegrityCheckSummary {
+  hashedFiles: number;
+  totalFiles: number;
+  hashedBytes: number;
+  totalBytes: number;
+}
+
 export interface LauncherSnapshot {
   appVersion: string;
   phase: LauncherPhase;
@@ -110,6 +121,7 @@ export interface LauncherSnapshot {
   playerIdentity: PlayerIdentitySummary;
   launcherUpdate: LauncherUpdateSummary;
   assetSync: AssetSyncSummary;
+  integrityCheck: IntegrityCheckSummary | null;
   progress: InstallProgress | null;
   error: string | null;
   gamePid: number | null;

--- a/src/components/LauncherFooter.tsx
+++ b/src/components/LauncherFooter.tsx
@@ -23,6 +23,11 @@ function statusCopy(snapshot: LauncherSnapshot, copy: Copy): { label: string; de
       const percent = Math.min(100, Math.round((assetProgress.completedBytes / assetProgress.totalBytes) * 100));
       return { label: copy.footer.launching, detail: `${copy.assets.updating} — ${percent}%` };
     }
+    const integrity = snapshot.integrityCheck;
+    if (integrity && integrity.totalFiles > 0) {
+      const percent = Math.min(100, Math.round((integrity.hashedFiles / integrity.totalFiles) * 100));
+      return { label: copy.footer.launching, detail: `${copy.integrity.verifying} — ${percent}%` };
+    }
     return { label: copy.footer.launching, detail: copy.footer.preparingClient };
   }
   if (snapshot.phase === "installing") return { label: copy.footer.installing, detail: copy.footer.secureCopy };

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -122,6 +122,9 @@ export interface Copy {
     progressPhases: Record<"scanning" | "copying" | "verifying" | "configuring" | "finalizing", string>;
     progressFiles: Record<"scanning" | "verifying" | "configuring" | "finalizing", string>;
   };
+  integrity: {
+    verifying: string;
+  };
   assets: {
     title: string;
     description: string;
@@ -259,6 +262,9 @@ const COPY: Record<AppLocale, Copy> = {
         configuring: "Applying ROTK client configuration",
         finalizing: "Atomic finalization",
       },
+    },
+    integrity: {
+      verifying: "VERIFYING GAME FILES",
     },
     assets: {
       title: "CUSTOM ASSETS",
@@ -407,6 +413,9 @@ const COPY: Record<AppLocale, Copy> = {
         configuring: "Application du client ROTK",
         finalizing: "Finalisation atomique",
       },
+    },
+    integrity: {
+      verifying: "VÉRIFICATION DES FICHIERS DU JEU",
     },
     assets: {
       title: "ASSETS PERSONNALISÉS",

--- a/tests/asset-sync.test.ts
+++ b/tests/asset-sync.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   AssetSyncService,
   parseAssetManifest,
+  stripByteOrderMark,
   type AssetManifest,
   type AssetManifestEntry,
 } from "../electron/services/asset-sync.js";
@@ -118,6 +119,11 @@ describe("ROTK asset sync", () => {
       expect(() => parseAssetManifest(duplicated)).toThrow("asset en double");
       expect(() => parseAssetManifest(withEntry({ sha256: "beef" }))).toThrow("sha256 invalide");
       expect(() => parseAssetManifest(withEntry({ size: 0 }))).toThrow("taille invalide");
+      // A BOM-prefixed feed must still parse: Windows tooling emits one and it
+      // would otherwise stop every launcher.
+      expect(stripByteOrderMark("﻿{\"a\":1}")).toBe("{\"a\":1}");
+      expect(stripByteOrderMark("{\"a\":1}")).toBe("{\"a\":1}");
+      expect(JSON.parse(stripByteOrderMark("﻿{\"ok\":true}"))).toEqual({ ok: true });
       expect(() => parseAssetManifest(withEntry({ size: 4 * 1024 ** 4 }))).toThrow("taille invalide");
     });
   });

--- a/tests/attestation.test.ts
+++ b/tests/attestation.test.ts
@@ -1,0 +1,139 @@
+import { generateKeyPairSync, sign as signPayload, type KeyObject } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  ATTESTATION_TEST_VECTORS,
+  AttestationFormatError,
+  challengeSigningInput,
+  computeAttestationEvidence,
+  computeManifestRoot,
+  isManifestPath,
+  isSha256Hex,
+  manifestPathKey,
+  manifestSigningInput,
+  verifyAttestationSignature,
+} from "../shared/attestation";
+
+function ed25519KeyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const pkcs8 = privateKey.export({ format: "der", type: "pkcs8" }) as Buffer;
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  return { privateKey, publicKeyRaw: spki.subarray(spki.length - 32).toString("base64url"), pkcs8 };
+}
+
+function sign(input: string, privateKey: KeyObject) {
+  return signPayload(null, Buffer.from(input, "utf8"), privateKey).toString("base64url");
+}
+
+describe("canonical manifest root", () => {
+  it("matches the frozen cross-implementation vector", () => {
+    const { entries, expectedRoot } = ATTESTATION_TEST_VECTORS.manifestRoot;
+    expect(computeManifestRoot(entries)).toBe(expectedRoot);
+  });
+
+  it("is independent of input order but ordered by lowercased path", () => {
+    const { entries, expectedRoot } = ATTESTATION_TEST_VECTORS.manifestRoot;
+    expect(computeManifestRoot([...entries].reverse())).toBe(expectedRoot);
+    expect(manifestPathKey("Resources/Assets/A.pack2")).toBe("resources/assets/a.pack2");
+  });
+
+  it("changes when any file content, name or presence changes", () => {
+    const base = [{ path: "a.pack2", size: 1, sha256: "a".repeat(64) }];
+    expect(computeManifestRoot(base)).not.toBe(
+      computeManifestRoot([{ path: "a.pack2", size: 1, sha256: "b".repeat(64) }]),
+    );
+    expect(computeManifestRoot(base)).not.toBe(
+      computeManifestRoot([{ path: "b.pack2", size: 1, sha256: "a".repeat(64) }]),
+    );
+    expect(computeManifestRoot(base)).not.toBe(computeManifestRoot([]));
+  });
+
+  it("rejects duplicate, escaping and malformed entries", () => {
+    const valid = { path: "H1Z1.exe", size: 1, sha256: "a".repeat(64) };
+    expect(() => computeManifestRoot([valid, { ...valid, path: "h1z1.exe" }])).toThrow(AttestationFormatError);
+    expect(() => computeManifestRoot([{ ...valid, path: "../escape" }])).toThrow(AttestationFormatError);
+    expect(() => computeManifestRoot([{ ...valid, path: "/absolute" }])).toThrow(AttestationFormatError);
+    expect(() => computeManifestRoot([{ ...valid, path: "back\\slash" }])).toThrow(AttestationFormatError);
+    expect(() => computeManifestRoot([{ ...valid, sha256: "ABCDEF" }])).toThrow(AttestationFormatError);
+    expect(() => computeManifestRoot([{ ...valid, size: -1 }])).toThrow(AttestationFormatError);
+  });
+});
+
+describe("attestation evidence", () => {
+  it("matches the frozen cross-implementation vector", () => {
+    const { nonce, root, expectedEvidence } = ATTESTATION_TEST_VECTORS.evidence;
+    expect(computeAttestationEvidence(nonce, root)).toBe(expectedEvidence);
+  });
+
+  it("binds the nonce, so a captured response cannot be replayed", () => {
+    const { nonce, root } = ATTESTATION_TEST_VECTORS.evidence;
+    expect(computeAttestationEvidence(nonce, root)).not.toBe(
+      computeAttestationEvidence("YW5vdGhlci1ub25jZS0xMjM0NTY3", root),
+    );
+  });
+
+  it("rejects malformed nonces and roots", () => {
+    expect(() => computeAttestationEvidence("short", "a".repeat(64))).toThrow(AttestationFormatError);
+    expect(() => computeAttestationEvidence("dGVzdC1ub25jZS0xMjM0NTY3ODkw", "nope")).toThrow(AttestationFormatError);
+    expect(() => computeAttestationEvidence("has spaces and is long enough", "a".repeat(64)))
+      .toThrow(AttestationFormatError);
+  });
+});
+
+describe("signature verification", () => {
+  it("accepts a signature from a trusted key and rejects everything else", () => {
+    const { privateKey, publicKeyRaw } = ed25519KeyPair();
+    const trusted = { "test-key-1": publicKeyRaw };
+    const input = challengeSigningInput({
+      challengeId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+      nonce: ATTESTATION_TEST_VECTORS.evidence.nonce,
+      policyVersion: "2026.08.01-1",
+      expiresAt: "2026-08-01T00:00:00.000Z",
+    });
+    const signature = sign(input, privateKey);
+
+    expect(verifyAttestationSignature(input, signature, "test-key-1", trusted)).toBe(true);
+    expect(verifyAttestationSignature(`${input}x`, signature, "test-key-1", trusted)).toBe(false);
+    expect(verifyAttestationSignature(input, signature, "unknown-key", trusted)).toBe(false);
+    expect(verifyAttestationSignature(input, signature, "test-key-1", { "test-key-1": ed25519KeyPair().publicKeyRaw }))
+      .toBe(false);
+  });
+
+  it("fails closed on malformed inputs instead of throwing", () => {
+    const trusted = { "test-key-1": ed25519KeyPair().publicKeyRaw };
+    expect(verifyAttestationSignature("payload", "not base64url!", "test-key-1", trusted)).toBe(false);
+    expect(verifyAttestationSignature("payload", "aGk", "test-key-1", trusted)).toBe(false);
+    expect(verifyAttestationSignature("payload", null, "test-key-1", trusted)).toBe(false);
+    expect(verifyAttestationSignature("payload", "a".repeat(86), null, trusted)).toBe(false);
+    // A prototype-polluting keyId must not resolve to Object.prototype members.
+    expect(verifyAttestationSignature("payload", "a".repeat(86), "toString", trusted)).toBe(false);
+  });
+
+  it("covers every identity-bearing manifest field", () => {
+    const document = {
+      kind: "base-game",
+      schemaVersion: 1,
+      version: "1.0.326.439939",
+      root: "a".repeat(64),
+      issuedAt: "2026-08-01T00:00:00.000Z",
+      expiresAt: null,
+    };
+    const base = manifestSigningInput(document);
+    for (const field of ["kind", "version", "root", "issuedAt"] as const) {
+      expect(manifestSigningInput({ ...document, [field]: "changed" })).not.toBe(base);
+    }
+    expect(manifestSigningInput({ ...document, expiresAt: "2026-09-01T00:00:00.000Z" })).not.toBe(base);
+  });
+});
+
+describe("format guards", () => {
+  it("validates digests and paths", () => {
+    expect(isSha256Hex("a".repeat(64))).toBe(true);
+    expect(isSha256Hex("A".repeat(64))).toBe(false);
+    expect(isSha256Hex("a".repeat(63))).toBe(false);
+    expect(isManifestPath("Resources/Assets/a.pack2")).toBe(true);
+    expect(isManifestPath("")).toBe(false);
+    expect(isManifestPath("../a")).toBe(false);
+    expect(isManifestPath("a//b")).toBe(false);
+    expect(isManifestPath("C:\\game\\a.pack2")).toBe(false);
+  });
+});

--- a/tests/client-config.test.ts
+++ b/tests/client-config.test.ts
@@ -14,6 +14,7 @@ const runtime: RuntimeConfig = {
   loginPorts: [20042, 20043],
   websiteOrigin: "https://rotk.app",
   launchTicketUrl: "https://accounts.rotk.app/createLaunchTicket",
+  attestationChallengeUrl: "https://accounts.rotk.app/beginLauncherAttestation",
 };
 const authKey = "0123456789abcdef0123456789abcdef";
 const localCreateSessionUrl = "http://127.0.0.1:49152/rest/auth/session/create";

--- a/tests/integrity-attestation.test.ts
+++ b/tests/integrity-attestation.test.ts
@@ -1,0 +1,435 @@
+import { createHash, generateKeyPairSync, sign as signPayload } from "node:crypto";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { challengeSigningInput, computeAttestationEvidence, computeManifestRoot } from "../shared/attestation";
+import {
+  buildAttestationResult,
+  integrityAttestationInternals,
+  measureInstallation,
+  requestAttestationChallenge,
+} from "../electron/services/integrity-attestation";
+import {
+  isAttestationExcluded,
+  mergeExpectedFiles,
+  parseBaseManifest,
+  readLauncherOverrides,
+} from "../electron/services/base-manifest";
+
+const LAUNCHER_VERSION = "1.4.0";
+const CHALLENGE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const PLAYER_KEY = "0123456789abcdef0123456789abcdef";
+const ENDPOINT = "https://accounts.rotk.app/beginLauncherAttestation";
+
+let workspace: string;
+let installRoot: string;
+let userData: string;
+
+function keyPair() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const spki = publicKey.export({ format: "der", type: "spki" }) as Buffer;
+  return { privateKey, publicKeyRaw: spki.subarray(spki.length - 32).toString("base64url") };
+}
+
+function sha256(content: string) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+async function writeGameFile(relativePath: string, content: string) {
+  const absolute = join(installRoot, ...relativePath.split("/"));
+  await mkdir(join(absolute, ".."), { recursive: true });
+  await writeFile(absolute, content, "utf8");
+  return { path: relativePath, size: Buffer.byteLength(content), sha256: sha256(content) };
+}
+
+beforeEach(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "rotk-attest-"));
+  installRoot = join(workspace, "game");
+  userData = join(workspace, "userdata");
+  await mkdir(installRoot, { recursive: true });
+  await mkdir(userData, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(workspace, { recursive: true, force: true });
+});
+
+describe("measureInstallation", () => {
+  it("reports a clean installation with a root matching the expected manifest", async () => {
+    const expected = [
+      await writeGameFile("H1Z1.exe", "executable bytes"),
+      await writeGameFile("Resources/Assets/assets_x64_0.pack2", "smoke and world assets"),
+    ];
+    const measurement = await measureInstallation({ installationRoot: installRoot, userDataDirectory: userData, expected });
+
+    expect(measurement.deviations).toEqual([]);
+    expect(measurement.fileCount).toBe(2);
+    expect(measurement.root).toBe(computeManifestRoot(expected));
+  });
+
+  it("detects a deleted smoke asset — the exact cheat this defends against", async () => {
+    const kept = await writeGameFile("H1Z1.exe", "executable bytes");
+    const smoke = { path: "Resources/Assets/assets_smoke.pack2", size: 21, sha256: sha256("smoke effects file") };
+    // The file is declared by the manifest but never written: the player removed it.
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [kept, smoke],
+    });
+
+    expect(measurement.deviations).toEqual([
+      { path: "Resources/Assets/assets_smoke.pack2", kind: "missing", observedSha256: null },
+    ]);
+    expect(measurement.root).not.toBe(computeManifestRoot([kept, smoke]));
+  });
+
+  it("detects an altered file and reports the observed digest", async () => {
+    const declared = await writeGameFile("Resources/Assets/assets_x64_0.pack2", "original contents");
+    const tampered = { ...declared, sha256: sha256("what the manifest expected") };
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [tampered],
+    });
+
+    expect(measurement.deviations).toEqual([
+      { path: "Resources/Assets/assets_x64_0.pack2", kind: "mismatch", observedSha256: declared.sha256 },
+    ]);
+  });
+
+  it("reports files that no manifest declares", async () => {
+    const declared = await writeGameFile("H1Z1.exe", "executable");
+    await writeGameFile("Resources/Assets/injected.pack2", "added by the player");
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [declared],
+      unexpectedPaths: ["Resources/Assets/injected.pack2"],
+    });
+
+    expect(measurement.deviations).toEqual([
+      { path: "Resources/Assets/injected.pack2", kind: "unexpected", observedSha256: sha256("added by the player") },
+    ]);
+  });
+
+  it("discovers undeclared content by walking the tree", async () => {
+    const declared = await writeGameFile("H1Z1.exe", "executable");
+    await writeGameFile("Resources/Assets/injected.pack2", "smuggled content");
+    await writeGameFile("Resources/Assets/cheat.dll", "code");
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [declared],
+      detectUnexpected: true,
+    });
+
+    expect(measurement.deviations.map((deviation) => deviation.path).sort()).toEqual([
+      "Resources/Assets/cheat.dll",
+      "Resources/Assets/injected.pack2",
+    ]);
+    expect(measurement.deviations.every((deviation) => deviation.kind === "unexpected")).toBe(true);
+  });
+
+  it("does not flag per-player settings, logs or uninteresting extensions", async () => {
+    const declared = await writeGameFile("H1Z1.exe", "executable");
+    // Legitimately present and legitimately undeclared.
+    await writeGameFile("UserOptions.ini", "[Display]\nGamma=1");
+    await writeGameFile("InputProfile_User.xml", "<Profile/>");
+    await writeGameFile("Logs/ClientItemsInfo.log", "noise");
+    await writeGameFile("BattlEye/BEClient_x64.dll", "battleye updates itself");
+    await writeGameFile("readme.txt", "harmless");
+
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [declared],
+      detectUnexpected: true,
+    });
+    expect(measurement.deviations).toEqual([]);
+  });
+
+  it("caches digests across runs and still produces the same root", async () => {
+    const expected = [await writeGameFile("Resources/Assets/big.pack2", "expensive to hash")];
+    const first = await measureInstallation({ installationRoot: installRoot, userDataDirectory: userData, expected });
+    const cache = await integrityAttestationInternals.loadCache(userData);
+    expect(cache.size).toBe(1);
+
+    const second = await measureInstallation({ installationRoot: installRoot, userDataDirectory: userData, expected });
+    expect(second.root).toBe(first.root);
+    expect(second.deviations).toEqual([]);
+  });
+
+  it("does not let a stale cache entry mask a modified file", async () => {
+    const declared = await writeGameFile("Resources/Assets/a.pack2", "original");
+    await measureInstallation({ installationRoot: installRoot, userDataDirectory: userData, expected: [declared] });
+
+    // Rewrite with different content and length: size alone invalidates the entry.
+    await writeFile(join(installRoot, "Resources", "Assets", "a.pack2"), "tampered contents", "utf8");
+    const measurement = await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected: [declared],
+    });
+    expect(measurement.deviations[0]?.kind).toBe("mismatch");
+  });
+
+  it("reports progress while measuring", async () => {
+    const expected = [await writeGameFile("H1Z1.exe", "bytes")];
+    const phases: string[] = [];
+    await measureInstallation({
+      installationRoot: installRoot,
+      userDataDirectory: userData,
+      expected,
+      onProgress: (progress) => phases.push(progress.phase),
+    });
+    expect(phases[0]).toBe("measuring");
+    expect(phases.at(-1)).toBe("done");
+  });
+});
+
+describe("challenge handling", () => {
+  it("accepts a challenge signed by a trusted key", async () => {
+    const { privateKey, publicKeyRaw } = keyPair();
+    const challenge = {
+      challengeId: CHALLENGE_ID,
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3ODkw",
+      policyVersion: "2026.08.01-1",
+      packVersion: "1.1.0",
+      baseBuildId: "1.0.326.439939",
+      minLauncherVersion: "1.4.0",
+      expiresAt: "2026-08-01T00:15:00.000Z",
+      keyId: "test-key",
+    };
+    const signature = signPayload(
+      null,
+      Buffer.from(challengeSigningInput(challenge), "utf8"),
+      privateKey,
+    ).toString("base64url");
+    const fetchImpl = (async () => new Response(
+      JSON.stringify({ ok: true, ...challenge, signature }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+
+    const parsed = await requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, {
+      fetchImpl,
+      trustedKeys: { "test-key": publicKeyRaw },
+    });
+    expect(parsed.challengeId).toBe(CHALLENGE_ID);
+    expect(parsed.nonce).toBe(challenge.nonce);
+  });
+
+  it("refuses a challenge signed by an untrusted key — a spoofed backend cannot steer measurement", async () => {
+    const { privateKey } = keyPair();
+    const challenge = {
+      challengeId: CHALLENGE_ID,
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3ODkw",
+      policyVersion: "2026.08.01-1",
+      packVersion: "1.1.0",
+      baseBuildId: "1.0.326.439939",
+      minLauncherVersion: "1.4.0",
+      expiresAt: "2026-08-01T00:15:00.000Z",
+      keyId: "test-key",
+    };
+    const signature = signPayload(
+      null,
+      Buffer.from(challengeSigningInput(challenge), "utf8"),
+      privateKey,
+    ).toString("base64url");
+    const fetchImpl = (async () => new Response(
+      JSON.stringify({ ok: true, ...challenge, signature }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, {
+        fetchImpl,
+        trustedKeys: { "test-key": keyPair().publicKeyRaw },
+      }),
+    ).rejects.toThrow(/not signed by a trusted key/);
+    // No key shipped in the pinned table yet: the default path also fails closed.
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl }),
+    ).rejects.toThrow(/not signed by a trusted key/);
+  });
+
+  it("rejects an unsigned or malformed challenge", async () => {
+    const fetchImpl = (async () => new Response(
+      JSON.stringify({ ok: true, challengeId: CHALLENGE_ID }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl }),
+    ).rejects.toThrow(/Invalid attestation challenge/);
+  });
+
+  it("maps service errors to actionable messages", async () => {
+    const errorFetch = (code: string) => (async () => new Response(
+      JSON.stringify({ ok: false, error: code }),
+      { status: 401, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl: errorFetch("invalid_credentials") }),
+    ).rejects.toThrow(/launcher key was rejected/);
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl: errorFetch("policy_unavailable") }),
+    ).rejects.toThrow(/no published integrity policy/);
+  });
+
+  it("refuses non-HTTPS endpoints", async () => {
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, "http://accounts.rotk.app/x", LAUNCHER_VERSION),
+    ).rejects.toThrow(/Invalid ROTK attestation endpoint/);
+  });
+});
+
+describe("buildAttestationResult", () => {
+  it("binds the measurement to the challenge nonce", async () => {
+    const expected = [await writeGameFile("H1Z1.exe", "bytes")];
+    const measurement = await measureInstallation({ installationRoot: installRoot, userDataDirectory: userData, expected });
+    const challenge = {
+      challengeId: CHALLENGE_ID,
+      nonce: "dGVzdC1ub25jZS0xMjM0NTY3ODkw",
+      policyVersion: "2026.08.01-1",
+      packVersion: "1.1.0",
+      baseBuildId: "1.0.326.439939",
+      minLauncherVersion: "1.4.0",
+      expiresAt: "2026-08-01T00:15:00.000Z",
+      keyId: "test-key",
+      signature: "unused-here",
+    };
+    const result = buildAttestationResult(challenge, measurement, LAUNCHER_VERSION);
+
+    expect(result.evidence).toBe(computeAttestationEvidence(challenge.nonce, measurement.root));
+    expect(result.claim).toEqual({
+      policyVersion: "2026.08.01-1",
+      packVersion: "1.1.0",
+      baseBuildId: "1.0.326.439939",
+      launcherVersion: LAUNCHER_VERSION,
+      fileCount: 1,
+      totalBytes: measurement.totalBytes,
+    });
+    // A different nonce yields different evidence: replay is worthless.
+    expect(buildAttestationResult({ ...challenge, nonce: "YW5vdGhlci1ub25jZS0xMjM0NQ" }, measurement, LAUNCHER_VERSION).evidence)
+      .not.toBe(result.evidence);
+  });
+});
+
+describe("expected-file merge", () => {
+  it("layers assets over the base tree and drops per-player and launcher-rewritten files", () => {
+    const base = [
+      { path: "H1Z1.exe", size: 1, sha256: "a".repeat(64) },
+      { path: "ClientConfig.ini", size: 2, sha256: "b".repeat(64) },
+      { path: "Resources/Assets/a.pack2", size: 3, sha256: "c".repeat(64) },
+    ];
+    const assets = [{ path: "Resources/Assets/a.pack2", size: 4, sha256: "d".repeat(64) }];
+    const merged = mergeExpectedFiles(base, assets);
+
+    expect(merged.map((entry) => entry.path).sort()).toEqual(["H1Z1.exe", "Resources/Assets/a.pack2"]);
+    // An asset legitimately replaces its base counterpart.
+    expect(merged.find((entry) => entry.path === "Resources/Assets/a.pack2")?.sha256).toBe("d".repeat(64));
+  });
+
+  it("excludes every file that legitimately differs between honest players", () => {
+    // These are written by the game per player; attesting them would reject
+    // everyone who ever changed a graphics setting or a keybind.
+    for (const path of [
+      "UserOptions.ini",
+      "InputProfile_User.xml",
+      "ClientConfig.ini",
+      "steam_persona_name.txt",
+      ".rotk-installation.json",
+      "ClientConfig.original.ini",
+      "steam_api64.original.dll",
+      "BattlEye/BEClient_x64.cfg",
+      "Logs/ClientItemsInfo.log",
+      "logs/anything.txt",
+    ]) {
+      expect(isAttestationExcluded(path)).toBe(true);
+    }
+  });
+
+  it("never excludes gameplay content or the shim it protects", () => {
+    for (const path of [
+      "H1Z1.exe",
+      "steam_api64.dll",
+      "Resources/Assets/assets_x64_0.pack2",
+      "Resources/Assets/ui_x64_4.pack2",
+      "vivoxsdk_x64.dll",
+    ]) {
+      expect(isAttestationExcluded(path)).toBe(false);
+    }
+  });
+
+  it("matches case-insensitively, as Windows paths do", () => {
+    expect(isAttestationExcluded("USEROPTIONS.INI")).toBe(true);
+    expect(isAttestationExcluded("battleye/BEClient_x64.dll")).toBe(true);
+  });
+
+  it("expects the launcher artifact for a file it replaces, not the vanilla one", async () => {
+    // steam_api64.dll is swapped for the ROTK shim. Measured on a real pair of
+    // trees: after exclusions it is the ONLY content difference between a
+    // vanilla and a ROTK install, so it must be attested as an override.
+    const shim = "d".repeat(64);
+    const base = [
+      { path: "steam_api64.dll", size: 235_600, sha256: "a".repeat(64) },
+      { path: "H1Z1.exe", size: 1, sha256: "b".repeat(64) },
+    ];
+    const merged = mergeExpectedFiles(base, [], [{ path: "steam_api64.dll", size: 221_696, sha256: shim }]);
+
+    expect(merged.find((entry) => entry.path === "steam_api64.dll")?.sha256).toBe(shim);
+    expect(merged).toHaveLength(2);
+  });
+
+  it("reads override hashes from the shipped sha256 sidecars", async () => {
+    const dll = join(workspace, "steam_api64.dll");
+    await writeFile(dll, "shim bytes", "utf8");
+    await writeFile(`${dll}.sha256`, `${sha256("shim bytes")} *steam_api64.dll\n`, "utf8");
+
+    const overrides = await readLauncherOverrides([{ installPath: "steam_api64.dll", bundledPath: dll }]);
+    expect(overrides).toEqual([
+      { path: "steam_api64.dll", size: Buffer.byteLength("shim bytes"), sha256: sha256("shim bytes") },
+    ]);
+  });
+
+  it("yields no override when the sidecar is missing or malformed", async () => {
+    const dll = join(workspace, "vivoxsdk_x64.dll");
+    await writeFile(dll, "bytes", "utf8");
+    // No sidecar: the file falls back to the vanilla hash and surfaces as a
+    // deviation — visible and safe, never silently trusted.
+    expect(await readLauncherOverrides([{ installPath: "vivoxsdk_x64.dll", bundledPath: dll }])).toEqual([]);
+
+    await writeFile(`${dll}.sha256`, "not-a-digest\n", "utf8");
+    expect(await readLauncherOverrides([{ installPath: "vivoxsdk_x64.dll", bundledPath: dll }])).toEqual([]);
+  });
+});
+
+describe("parseBaseManifest", () => {
+  it("rejects an unsigned manifest", () => {
+    expect(() => parseBaseManifest({
+      schemaVersion: 1,
+      kind: "base-game",
+      buildId: "1.0.326.439939",
+      root: "a".repeat(64),
+      issuedAt: "2026-08-01T00:00:00.000Z",
+      keyId: "unknown-key",
+      signature: "a".repeat(86),
+      files: [{ path: "H1Z1.exe", size: 1, sha256: "b".repeat(64) }],
+    })).toThrow(/signature non reconnue/);
+  });
+
+  it("rejects structural problems before looking at the signature", () => {
+    expect(() => parseBaseManifest({ schemaVersion: 2 })).toThrow(/version non prise en charge/);
+    expect(() => parseBaseManifest({ schemaVersion: 1, kind: "other" })).toThrow(/type inattendu/);
+    expect(() => parseBaseManifest({
+      schemaVersion: 1,
+      kind: "base-game",
+      buildId: "x",
+      root: "a".repeat(64),
+      issuedAt: "now",
+      keyId: "k",
+      signature: "s",
+      files: [{ path: "../escape", size: 1, sha256: "b".repeat(64) }],
+    })).toThrow(/chemin invalide/);
+  });
+});


### PR DESCRIPTION
## What this does

The launcher now proves to the ROTK backend that the installation is the base
game plus the official asset packs, **before** a launch ticket is issued.
Deleting the smoke assets to see through smoke no longer goes unnoticed.

Per launch: request a signed single-use challenge, verify its Ed25519 signature
against the keys pinned in `shared/attestation.ts` (a spoofed backend must not
be able to steer what we measure), hash the declared installation, and send
`SHA-256(nonce ‖ canonical root)` with the ticket request. The server compares
against its own expected root, so recompiling this launcher to claim success
achieves nothing.

`docs/SPEC_LAUNCHER_ATTESTATION.md` §2 is explicit about what this cannot do:
the launcher runs on the attacker's machine, so a determined cheater can keep
pristine copies and have those measured. The goal is to make cheating costly
and to **detect and log** the naive attempts, which are nearly all real cases.

**Nothing blocks a player**: the server runs in observation mode, and admin
accounts are permanently exempt.

## Points worth reviewing

- **Exclusion list** (`ATTESTATION_EXCLUDED_PATHS`): verified against a real
  pristine/patched pair of trees. The game rewrites `UserOptions.ini` and
  `InputProfile_User.xml` every session and both differ per player — attesting
  them would have rejected every player who ever changed a setting or a
  keybind. No `pack2`, `exe` or non-backup `dll` may ever be excluded, and a
  test enforces that. Committed 563 attested files, 81 excluded.
- **`steam_api64.dll` is not excluded**: the launcher replaces it with the ROTK
  shim, so it is attested against the shim hash read from the shipped
  `.sha256` sidecar. Excluding it would let a cheat DLL take its place.
- **Hash cache** keyed by `(path, size, mtime)` makes later launches
  near-instant. It can only ever cause a rejection, never a false pass.
- **Asset caps raised** to 3 GB per asset / 8 GB total: the main pack is
  2.47 GB uncompressed. Requires the 1.1.0 feed, already published.
- **BOM tolerance**: PowerShell emits a UTF-8 BOM and `JSON.parse` rejects it —
  a feed published with one would have stopped every launcher.

## Tooling

`generate-attestation-keypair`, `generate-base-manifest` (signed manifest of a
pristine install) and `package-asset-packs` (one zip per pack so an update only
re-downloads what changed, plus the installed-file hashes the server folds into
its expected root).

Version bumped to 0.7.0 to match the published policy's `minLauncherVersion`.

Tests: 127/127, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)