### PR TITLE
Auto-discover new asset packs from GitHub releases

### DIFF
--- a/docs/asset-packs.md
+++ b/docs/asset-packs.md
@@ -12,20 +12,23 @@ requiring a launcher release. The pipeline is implemented by
 1. Fetch `feed.json` from
    `https://raw.githubusercontent.com/h1z1rotk/assets/main/feed.json`
    (HTTPS only, 10 s timeout, 1 MB cap).
-2. Diff against the local state (`asset-state.v1.json` in the launcher `userData`):
+2. Fetch the latest stable GitHub release metadata. Every conventional `foo.zip`
+   release asset is merged over the feed as `Resources/Assets/foo.pack2`, using the
+   size and SHA-256 digest returned by GitHub.
+3. Diff the merged catalog against the local state (`asset-state.v1.json` in the launcher `userData`):
    an asset is (re)installed when it is new, its `version`/`sha256` changed, or one of
    its installed files is missing (the **Verify files** action additionally re-hashes
    every installed file).
-3. Download into `userData/asset-cache/` (a cached pack with the right SHA-256 is
+4. Download into `userData/asset-cache/` (a cached pack with the right SHA-256 is
    reused without any network call), verify the streamed SHA-256 against the manifest,
    then install atomically (staging file + `rename`) into the ROTK installation.
-4. Client files overwritten for the first time are backed up under
+5. Client files overwritten for the first time are backed up under
    `userData/asset-backups/` — **Restore vanilla client** puts them back and deletes
-   everything the feed added.
-5. Assets removed from the manifest are uninstalled on the next sync (backup restored
+   everything the merged catalog added.
+6. Assets removed from the merged catalog are uninstalled on the next sync (backup restored
    or file deleted).
 
-A feed that cannot be fetched **never blocks the game** once a first sync completed:
+Metadata that cannot be fetched **never blocks the game** once a first sync completed:
 the launcher shows a warning and starts with the assets already on disk. Only a first
 sync that never completed is blocking (players can also disable the sync entirely in
 the setup panel — offline/dev mode).
@@ -35,8 +38,9 @@ the setup panel — offline/dev mode).
 - `feed.json` at the root of `main` — the always-current manifest.
 - Binaries attached as **GitHub Release assets** (never committed): stable URLs, no
   git size limits.
-- Publishing an update = upload a release (`assets-vX.Y.Z`) + one commit updating
-  `feed.json` (URLs + SHA-256 + sizes + bumped `packVersion`).
+- Every conventional `foo.zip` uploaded to the latest stable release is discovered
+  automatically as `Resources/Assets/foo.pack2`; no `feed.json` edit is required.
+- `feed.json` remains available for non-pack payloads and explicit legacy entries.
 
 ## 3. Manifest format
 
@@ -102,14 +106,15 @@ The launcher refuses the whole pack if any rule fails — nothing is written hal
 
 1. Run `scripts/package-asset-packs.ps1 -SourceDirectory <packs dir>
    -OutputDirectory <out> -PackVersion X.Y.Z`. It zips **each file into its own
-   payload** (so launcher updates only re-download what changed), enforces the
-   section 4 caps and blocked extensions, computes `sha256`/`size` and writes
-   the ready-to-commit `feed.json`.
-2. Create the GitHub release `assets-vX.Y.Z` on `h1z1rotk/assets` and attach the
-   generated zips.
-3. Commit the generated `feed.json` to `main`.
-4. Done — launchers pick the update up at the next launch. To roll back, point
-   `feed.json` back to the previous release assets.
+   payload**, enforces the section 4 caps, and writes both `feed.json` and the
+   attestation payload manifest.
+2. Create the stable GitHub release `assets-vX.Y.Z` on `h1z1rotk/assets` and attach
+   the generated zips.
+3. Done for conventional pack ZIPs: launchers discover them from the latest release.
+4. Commit `feed.json` only for non-pack payloads or explicit legacy entries.
+5. Publish the generated attestation payload manifest with the server policy.
+6. At the next launch or **Verify files**, missing or changed packs are downloaded.
+   To roll back, remove/replace the release asset or publish a newer stable release.
 
 Manual fallback: build payloads yourself (avoid blocked extensions and
 protected paths), `Get-FileHash -Algorithm SHA256`, then edit `feed.json` by

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -605,9 +605,9 @@ function registerIpc(): void {
       phase = "launching";
       lastErrorRaw = null;
       await broadcastSnapshot();
-      // The custom assets are brought up to date before every launch. Only a
-      // first sync that never completed is allowed to block the game.
-      const assetResult = await runAssetSync("sync", true);
+      // A discovered update must be fully downloaded and installed before
+      // starting the game; launching with a partially updated asset set is unsafe.
+      const assetResult = await runAssetSync("sync", false);
       if (!assetResult.ok) {
         phase = "ready";
         await broadcastSnapshot();

--- a/electron/services/asset-sync.ts
+++ b/electron/services/asset-sync.ts
@@ -32,6 +32,7 @@ import { extractZipEntry, readZipDirectory } from "./zip-archive.js";
  */
 
 export const ASSET_FEED_URL = "https://raw.githubusercontent.com/h1z1rotk/assets/main/feed.json";
+export const ASSET_RELEASE_API_URL = "https://api.github.com/repos/h1z1rotk/assets/releases/latest";
 
 /** Hosts an asset URL may declare in the manifest. */
 const ASSET_URL_HOSTS = new Set(["github.com", "raw.githubusercontent.com"]);
@@ -41,8 +42,10 @@ const ASSET_REDIRECT_HOSTS = new Set([
   "objects.githubusercontent.com",
   "release-assets.githubusercontent.com",
 ]);
+const RELEASE_API_HOSTS = new Set(["api.github.com"]);
 
 const MAX_FEED_BYTES = 1_000_000;
+const MAX_RELEASE_METADATA_BYTES = 1_000_000;
 const MAX_ASSETS = 64;
 /**
  * Also bounds a single extracted zip entry: the main game pack
@@ -82,6 +85,8 @@ export interface AssetManifestEntry {
   size: number;
   installPath: string;
   type: "zip" | "file";
+  /** Exact root entry required for a pack auto-discovered from GitHub Releases. */
+  releasePackEntry?: string;
 }
 
 export interface AssetManifest {
@@ -119,8 +124,24 @@ export interface AssetSyncOutcome {
 export interface AssetSyncServiceOptions {
   userDataDirectory: string;
   feedUrl?: string;
+  releaseApiUrl?: string;
+  discoverReleaseAssets?: boolean;
   fetchImpl?: typeof fetch;
   onProgress?(progress: AssetSyncProgress): void;
+}
+
+interface GitHubReleaseAsset {
+  name?: unknown;
+  size?: unknown;
+  digest?: unknown;
+  browser_download_url?: unknown;
+}
+
+interface GitHubRelease {
+  tag_name?: unknown;
+  draft?: unknown;
+  prerelease?: unknown;
+  assets?: unknown;
 }
 
 function manifestError(reason: string): Error {
@@ -273,6 +294,93 @@ export function parseAssetManifest(value: unknown): AssetManifest {
   return { manifestVersion: 1, packVersion: manifest.packVersion, assets };
 }
 
+/**
+ * Make the published GitHub release authoritative for conventional one-pack
+ * ZIP payloads. A newly uploaded foo.zip is interpreted strictly as a ZIP
+ * containing exactly foo.pack2 at its root and installed in Resources/Assets.
+ * GitHub's size and SHA-256 digest become the download contract.
+ */
+export function mergeGitHubReleaseAssets(
+  manifest: AssetManifest,
+  value: unknown,
+): AssetManifest {
+  if (!value || typeof value !== "object") throw manifestError("release GitHub inattendue");
+  const release = value as GitHubRelease;
+  if (release.draft === true || release.prerelease === true) {
+    throw manifestError("release GitHub non stable");
+  }
+  if (
+    typeof release.tag_name !== "string"
+    || !/^assets-v[0-9]+\.[0-9]+\.[0-9]+$/.test(release.tag_name)
+  ) {
+    throw manifestError("tag de release GitHub invalide");
+  }
+  if (!Array.isArray(release.assets)) {
+    throw manifestError("liste de release GitHub manquante");
+  }
+  if (release.assets.length > MAX_ASSETS) {
+    throw manifestError("trop d'assets dans la release GitHub");
+  }
+
+  const releaseVersion = release.tag_name.slice("assets-v".length);
+  const byName = new Map(
+    manifest.assets.map((asset) => [
+      asset.name.toLocaleLowerCase("en-US"),
+      asset,
+    ] as const),
+  );
+  const releasePackEntries = new Map<string, string>();
+
+  for (const raw of release.assets as GitHubReleaseAsset[]) {
+    if (!raw || typeof raw !== "object" || typeof raw.name !== "string") continue;
+    if (!/^[a-z0-9][a-z0-9._-]{0,63}\.zip$/i.test(raw.name)) continue;
+
+    const stem = raw.name.slice(0, -".zip".length);
+    const name = stem.toLocaleLowerCase("en-US");
+    const digest = typeof raw.digest === "string" && raw.digest.startsWith("sha256:")
+      ? raw.digest.slice("sha256:".length).toLocaleLowerCase("en-US")
+      : "";
+    if (!isHex64(digest)) {
+      throw manifestError("empreinte GitHub absente (" + raw.name + ")");
+    }
+    if (!Number.isSafeInteger(raw.size) || (raw.size as number) <= 0) {
+      throw manifestError("taille GitHub invalide (" + raw.name + ")");
+    }
+
+    const expectedUrl = "https://github.com/h1z1rotk/assets/releases/download/"
+      + release.tag_name + "/" + raw.name;
+    if (raw.browser_download_url !== expectedUrl) {
+      throw manifestError("URL GitHub inattendue (" + raw.name + ")");
+    }
+
+    byName.set(name, {
+      name,
+      version: releaseVersion,
+      url: expectedUrl,
+      sha256: digest,
+      size: raw.size as number,
+      installPath: "Resources/Assets",
+      type: "zip",
+    });
+    releasePackEntries.set(name, stem + ".pack2");
+  }
+
+  const merged = parseAssetManifest({
+    manifestVersion: 1,
+    packVersion: releaseVersion,
+    assets: [...byName.values()],
+  });
+  return {
+    ...merged,
+    assets: merged.assets.map((asset) => {
+      const releasePackEntry = releasePackEntries.get(
+        asset.name.toLocaleLowerCase("en-US"),
+      );
+      return releasePackEntry ? { ...asset, releasePackEntry } : asset;
+    }),
+  };
+}
+
 function isInstalledFileRecord(value: unknown): value is InstalledFileRecord {
   if (!value || typeof value !== "object") return false;
   const record = value as Partial<InstalledFileRecord>;
@@ -323,6 +431,8 @@ export class AssetSyncService {
   private readonly cacheDirectory: string;
   private readonly backupDirectory: string;
   private readonly feedUrl: string;
+  private readonly releaseApiUrl: string;
+  private readonly discoverReleaseAssets: boolean;
   private readonly fetchImpl: typeof fetch;
   private readonly onProgress: (progress: AssetSyncProgress) => void;
   private lastProgressAt = 0;
@@ -332,6 +442,8 @@ export class AssetSyncService {
     this.cacheDirectory = join(options.userDataDirectory, CACHE_DIRECTORY_NAME);
     this.backupDirectory = join(options.userDataDirectory, BACKUP_DIRECTORY_NAME);
     this.feedUrl = options.feedUrl ?? ASSET_FEED_URL;
+    this.releaseApiUrl = options.releaseApiUrl ?? ASSET_RELEASE_API_URL;
+    this.discoverReleaseAssets = options.discoverReleaseAssets ?? true;
     this.fetchImpl = options.fetchImpl ?? fetch;
     this.onProgress = options.onProgress ?? (() => undefined);
   }
@@ -497,17 +609,36 @@ export class AssetSyncService {
       const response = await this.fetchFollowingRedirects(this.feedUrl, controller.signal);
       const body = await response.text();
       if (Buffer.byteLength(body, "utf8") > MAX_FEED_BYTES) throw new Error("Feed too large");
-      return parseAssetManifest(JSON.parse(stripByteOrderMark(body)));
+      const manifest = parseAssetManifest(JSON.parse(stripByteOrderMark(body)));
+      if (!this.discoverReleaseAssets) return manifest;
+
+      const releaseResponse = await this.fetchFollowingRedirects(
+        this.releaseApiUrl,
+        controller.signal,
+        RELEASE_API_HOSTS,
+      );
+      const releaseBody = await releaseResponse.text();
+      if (Buffer.byteLength(releaseBody, "utf8") > MAX_RELEASE_METADATA_BYTES) {
+        throw manifestError("metadonnees de release GitHub trop volumineuses");
+      }
+      return mergeGitHubReleaseAssets(
+        manifest,
+        JSON.parse(stripByteOrderMark(releaseBody)),
+      );
     } finally {
       clearTimeout(timeout);
       signal?.removeEventListener("abort", abortUpstream);
     }
   }
 
-  private async fetchFollowingRedirects(rawUrl: string, signal?: AbortSignal): Promise<Response> {
+  private async fetchFollowingRedirects(
+    rawUrl: string,
+    signal?: AbortSignal,
+    firstHopHosts: ReadonlySet<string> = ASSET_URL_HOSTS,
+  ): Promise<Response> {
     let url = new URL(rawUrl);
     for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
-      const allowedHosts = hop === 0 ? ASSET_URL_HOSTS : ASSET_REDIRECT_HOSTS;
+      const allowedHosts = hop === 0 ? firstHopHosts : ASSET_REDIRECT_HOSTS;
       if (url.protocol !== "https:" || !allowedHosts.has(url.hostname)) {
         throw new Error(`Hôte de téléchargement d’assets non autorisé : ${url.hostname}.`);
       }
@@ -606,6 +737,19 @@ export class AssetSyncService {
         entry,
         relativePath: validateInstallRelativePath(joinRelativePaths(packRoot, entry.name), "file"),
       }));
+
+    if (asset.releasePackEntry) {
+      const expected = asset.releasePackEntry.toLocaleLowerCase("en-US");
+      if (
+        files.length !== 1
+        || files[0].entry.name.toLocaleLowerCase("en-US") !== expected
+      ) {
+        throw new Error(
+          "Archive d'assets auto-decouverte invalide (" + asset.name + ") : "
+          + "elle doit contenir uniquement " + asset.releasePackEntry + ".",
+        );
+      }
+    }
 
     for (const { entry, relativePath } of files) {
       const target = this.resolveTarget(root, relativePath);

--- a/tests/asset-sync.test.ts
+++ b/tests/asset-sync.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  ASSET_RELEASE_API_URL,
   AssetSyncService,
+  mergeGitHubReleaseAssets,
   parseAssetManifest,
   stripByteOrderMark,
   type AssetManifest,
@@ -38,6 +40,25 @@ function assetEntry(
 
 function manifest(assets: AssetManifestEntry[], packVersion = "1.0.0"): AssetManifest {
   return { manifestVersion: 1, packVersion, assets };
+}
+
+function releaseAsset(name: string, payload: Buffer) {
+  return {
+    name,
+    size: payload.length,
+    digest: "sha256:" + sha256(payload),
+    browser_download_url:
+      "https://github.com/h1z1rotk/assets/releases/download/assets-v1.1.0/" + name,
+  };
+}
+
+function release(assets: ReturnType<typeof releaseAsset>[]) {
+  return {
+    tag_name: "assets-v1.1.0",
+    draft: false,
+    prerelease: false,
+    assets,
+  };
 }
 
 type RouteHandler = () => Response;
@@ -77,6 +98,7 @@ describe("ROTK asset sync", () => {
       userDataDirectory: userData,
       feedUrl: FEED_URL,
       fetchImpl: makeFetch(routes, calls),
+      discoverReleaseAssets: false,
     });
   }
 
@@ -126,6 +148,101 @@ describe("ROTK asset sync", () => {
       expect(JSON.parse(stripByteOrderMark("﻿{\"ok\":true}"))).toEqual({ ok: true });
       expect(() => parseAssetManifest(withEntry({ size: 4 * 1024 ** 4 }))).toThrow("taille invalide");
     });
+
+    it("discovers new pack ZIPs from the latest GitHub release", () => {
+      const oldPack = Buffer.from("old pack");
+      const updatedPackZip = Buffer.from("updated pack zip");
+      const movementPackZip = Buffer.from("movement pack zip");
+      const feed = manifest([
+        assetEntry("assets_x64_0", oldPack, {
+          type: "zip",
+          installPath: "Resources/Assets",
+        }),
+      ]);
+
+      const merged = mergeGitHubReleaseAssets(feed, release([
+        releaseAsset("assets_x64_0.zip", updatedPackZip),
+        releaseAsset("assets_x64_10.zip", movementPackZip),
+        releaseAsset("release-notes.txt", Buffer.from("ignored")),
+      ]));
+
+      expect(merged.packVersion).toBe("1.1.0");
+      expect(merged.assets.map((asset) => asset.name)).toEqual([
+        "assets_x64_0",
+        "assets_x64_10",
+      ]);
+      expect(merged.assets[0]).toMatchObject({
+        sha256: sha256(updatedPackZip),
+        releasePackEntry: "assets_x64_0.pack2",
+      });
+      expect(merged.assets[1]).toMatchObject({
+        url: "https://github.com/h1z1rotk/assets/releases/download/assets-v1.1.0/assets_x64_10.zip",
+        sha256: sha256(movementPackZip),
+        installPath: "Resources/Assets",
+        releasePackEntry: "assets_x64_10.pack2",
+      });
+    });
+
+    it("refuses an auto-discovered ZIP without GitHub SHA-256 metadata", () => {
+      const candidate = {
+        ...releaseAsset("assets_x64_10.zip", Buffer.from("pack")),
+        digest: null,
+      };
+      expect(() => mergeGitHubReleaseAssets(manifest([]), release([candidate as never])))
+        .toThrow("empreinte GitHub absente");
+    });
+  });
+
+  it("downloads a newly uploaded release pack before launch or Verify files", async () => {
+    const { userData, root } = await setup();
+    const packZip = buildZip([
+      { name: "assets_x64_10.pack2", data: "PS3 movement animations", method: 8 },
+    ]);
+    const metadata = release([releaseAsset("assets_x64_10.zip", packZip)]);
+    const downloadUrl = metadata.assets[0].browser_download_url;
+    const calls: string[] = [];
+    const sync = new AssetSyncService({
+      userDataDirectory: userData,
+      feedUrl: FEED_URL,
+      releaseApiUrl: ASSET_RELEASE_API_URL,
+      fetchImpl: makeFetch({
+        [FEED_URL]: () => new Response(JSON.stringify(manifest([]))),
+        [ASSET_RELEASE_API_URL]: () => new Response(JSON.stringify(metadata)),
+        [downloadUrl]: () => new Response(new Uint8Array(packZip)),
+      }, calls),
+    });
+
+    expect(await sync.sync(root)).toEqual({ status: "updated", packVersion: "1.1.0" });
+    expect(
+      await readFile(join(root, "Resources", "Assets", "assets_x64_10.pack2"), "utf8"),
+    ).toBe("PS3 movement animations");
+    expect(calls).toEqual([FEED_URL, ASSET_RELEASE_API_URL, downloadUrl]);
+    expect((await sync.readState())?.assets[0]).toMatchObject({
+      name: "assets_x64_10",
+      sha256: sha256(packZip),
+    });
+  });
+
+  it("rejects a release ZIP whose pack name does not match its asset name", async () => {
+    const { userData, root } = await setup();
+    const wrongZip = buildZip([{ name: "another.pack2", data: "wrong" }]);
+    const metadata = release([releaseAsset("assets_x64_10.zip", wrongZip)]);
+    const downloadUrl = metadata.assets[0].browser_download_url;
+    const sync = new AssetSyncService({
+      userDataDirectory: userData,
+      feedUrl: FEED_URL,
+      releaseApiUrl: ASSET_RELEASE_API_URL,
+      fetchImpl: makeFetch({
+        [FEED_URL]: () => new Response(JSON.stringify(manifest([]))),
+        [ASSET_RELEASE_API_URL]: () => new Response(JSON.stringify(metadata)),
+        [downloadUrl]: () => new Response(new Uint8Array(wrongZip)),
+      }, []),
+    });
+
+    await expect(sync.verify(root)).rejects.toThrow("doit contenir uniquement assets_x64_10.pack2");
+    await expect(
+      stat(join(root, "Resources", "Assets", "another.pack2")),
+    ).rejects.toThrow();
   });
 
   it("installs file and zip assets, backs up originals and keeps state", async () => {


### PR DESCRIPTION
## Root cause

`Verify files` only read `h1z1rotk/assets/main/feed.json`. Uploading `assets_x64_10.zip` to the `assets-v1.1.0` release did not add it to that manifest, so the launcher had no file, size, hash, or installation target to verify.

## Changes

- query the latest stable `h1z1rotk/assets` GitHub release before launch and during **Verify files**
- auto-discover every conventional `foo.zip` as `Resources/Assets/foo.pack2`
- use GitHub's published size and SHA-256 digest as the download contract
- require an auto-discovered ZIP to contain exactly one matching root entry (`foo.pack2`)
- merge release entries over the legacy feed, so newly uploaded or replaced packs are detected without a manual `feed.json` commit
- block game launch when a discovered asset update fails to download or install
- document the new publishing flow

## Real release validation

Validated `assets_x64_10.zip` from `assets-v1.1.0`:

- archive size: `125148517`
- SHA-256: `12a0513efc2eeffb22e0dc4ed7fc62559d1044a8f451fdac985b9d2bb9db7d8b`
- one entry: `assets_x64_10.pack2`
- installed pack size: `145928528`

## Checks

- `npm run typecheck`
- `npm test` — 18 files, 133 tests passed
- `npm run build`
