### PR TITLE
release: GAME 2 launcher v9.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ La clé est chiffrée par Electron `safeStorage` — Windows DPAPI sur la platef
 - Windows 10 ou 11 x64 ;
 - Node.js 22 ;
 - npm 10 ou ultérieur ;
-- [Zig 0.15.2](https://ziglang.org/download/0.15.2/) pour reconstruire le shim natif.
+- [Zig 0.15.2](https://ziglang.org/download/0.15.2/) pour reconstruire les DLL natives.
 
 Lancer l’application en développement :
 
@@ -57,6 +57,11 @@ cd rotk-launcher
 npm ci
 npm run dev
 ```
+
+Les commandes `dev`, `dev:isolated`, `dist` et `dist:dir` reconstruisent
+automatiquement le proxy vocal ROTK puis vérifient le runtime Vivox officiel
+avant de démarrer. Un worktree frais ne peut ainsi pas lancer un client avec
+un proxy absent ou incohérent.
 
 Le mode développeur normal réutilise la configuration du launcher installé. Pour un test volontairement isolé, sans toucher à cette configuration :
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Une installation terminée est mémorisée dans `%APPDATA%\ROTK Launcher\config.
 - shim `steam_api64.dll` open source, compilable de façon déterministe avec Zig ;
 - isolation Electron (`contextIsolation`, sandbox, IPC limité et navigation externe filtrée).
 
-La configuration intégrée cible actuellement le serveur OVH ROTK `51.255.160.224` et ses listeners login `20042` à `20045`. Le futur manifeste runtime HTTPS signé remplacera cette configuration bornée sans exposer d’arguments arbitraires au renderer.
+La branche `new-server` cible le serveur GAME 2 ROTK `162.19.94.95` et ses listeners login `20042` à `20045`. Le futur manifeste runtime HTTPS signé remplacera cette configuration bornée sans exposer d’arguments arbitraires au renderer.
 
 ## Authentification du compte joueur
 

--- a/electron/services/runtime-config.ts
+++ b/electron/services/runtime-config.ts
@@ -13,16 +13,16 @@ export interface RuntimeConfig {
 }
 
 /**
- * Public OVH bootstrap used until the signed HTTPS runtime manifest is
+ * Public GAME 2 bootstrap used until the signed HTTPS runtime manifest is
  * published. Switching infrastructure later changes this bounded contract,
  * never arbitrary renderer-provided launch arguments.
  */
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   environment: "production",
-  label: "ROTK Europe",
-  gatewayOrigin: "http://51.255.160.224",
+  label: "ROTK GAME 2",
+  gatewayOrigin: "http://162.19.94.95",
   voiceGrantOrigin: "https://vps-c717eb9e.vps.ovh.net",
-  loginHost: "51.255.160.224",
+  loginHost: "162.19.94.95",
   loginPorts: [20042, 20043, 20044, 20045],
   websiteOrigin: "https://rotk.app",
   launchTicketUrl: "https://europe-west1-rotk-project.cloudfunctions.net/createLaunchTicket",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "0.6.0",
+  "version": "9.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "0.6.0",
+      "version": "9.0.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "main": "dist-electron/electron/main.js",
   "scripts": {
     "postinstall": "node node_modules/electron/install.js",
+    "predev": "npm run prepare:vivox",
+    "predev:isolated": "npm run prepare:vivox",
     "dev": "npm run build:electron && concurrently -k \"vite\" \"tsc -p electron/tsconfig.json --watch --preserveWatchOutput\" \"wait-on tcp:5173 dist-electron/electron/main.js && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "dev:isolated": "npm run build:electron && concurrently -k \"vite\" \"tsc -p electron/tsconfig.json --watch --preserveWatchOutput\" \"wait-on tcp:5173 dist-electron/electron/main.js && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 ROTK_USER_DATA_DIR=.dev-data electron .\"",
     "build:electron": "tsc -p electron/tsconfig.json && esbuild electron/preload.ts --bundle --platform=node --format=cjs --external:electron --outfile=dist-electron/electron/preload.cjs",
@@ -17,10 +19,13 @@
     "typecheck": "tsc --noEmit && tsc -p electron/tsconfig.json --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "predist": "npm run prepare:vivox",
+    "predist:dir": "npm run prepare:vivox",
     "dist": "npm run build && electron-builder --win nsis",
     "dist:dir": "npm run build && electron-builder --win dir --config.forceCodeSigning=false --config.win.signExecutable=false",
     "build:shim": "powershell -NoProfile -ExecutionPolicy Bypass -File native/steamshim/build-steam-shim.ps1",
     "build:vivox": "powershell -NoProfile -ExecutionPolicy Bypass -File native/vivoxproxy/build-v5-compat.ps1 -OutputPath resources/patches/vivoxsdk_x64.dll",
+    "prepare:vivox": "npm run build:vivox && npm run verify:vivox-runtime",
     "verify:vivox-runtime": "node scripts/verify-vivox-runtime.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.9.0",
+  "version": "9.0.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { LauncherSnapshot, OperationResult } from "../shared/contracts";
+import { GlobalActivityCenter } from "./components/GlobalActivityCenter";
 import { InstallPanel } from "./components/InstallPanel";
 import { LauncherFooter } from "./components/LauncherFooter";
 import { NewsCarousel } from "./components/NewsCarousel";
@@ -92,6 +93,7 @@ export default function App() {
     <main className="launcher-shell">
       <WindowChrome appVersion={snapshot.appVersion} />
       <NewsCarousel updates={snapshot.updates} />
+      <GlobalActivityCenter snapshot={snapshot} />
       {(transientError || snapshot.error) && (
         <div className="error-toast" role="alert">
           <strong>{copy.app.operationInterrupted}</strong>

--- a/src/activity-state.ts
+++ b/src/activity-state.ts
@@ -1,0 +1,138 @@
+import type {
+  AssetSyncProgress,
+  InstallProgress,
+  LauncherSnapshot,
+} from "../shared/contracts";
+
+export type GlobalActivityKind =
+  | "installation"
+  | "asset-sync"
+  | "integrity"
+  | "launch"
+  | "launcher-update";
+
+export interface GlobalActivity {
+  id: "primary" | "launcher-update";
+  kind: GlobalActivityKind;
+  stage: InstallProgress["phase"] | AssetSyncProgress["phase"] | "launching" | "checking" | "downloading" | null;
+  detail: string | null;
+  progressPercent: number | null;
+  completedBytes: number | null;
+  totalBytes: number | null;
+  completedItems: number | null;
+  totalItems: number | null;
+}
+
+function ratioPercent(completed: number, total: number): number | null {
+  if (!Number.isFinite(completed) || !Number.isFinite(total) || total <= 0) return null;
+  return Math.min(100, Math.max(0, (completed / total) * 100));
+}
+
+function installActivity(snapshot: LauncherSnapshot): GlobalActivity | null {
+  if (snapshot.phase !== "installing") return null;
+  const progress = snapshot.progress;
+  const bytePercent = progress ? ratioPercent(progress.completedBytes, progress.totalBytes) : null;
+  const itemPercent = progress ? ratioPercent(progress.filesCompleted, progress.totalFiles) : null;
+  return {
+    id: "primary",
+    kind: "installation",
+    stage: progress?.phase ?? null,
+    detail: progress?.currentFile || null,
+    progressPercent: bytePercent ?? itemPercent,
+    completedBytes: progress?.totalBytes ? progress.completedBytes : null,
+    totalBytes: progress?.totalBytes || null,
+    completedItems: progress?.totalFiles ? progress.filesCompleted : null,
+    totalItems: progress?.totalFiles || null,
+  };
+}
+
+function assetActivity(snapshot: LauncherSnapshot): GlobalActivity | null {
+  const { status, progress } = snapshot.assetSync;
+  if (status !== "checking" && status !== "downloading" && status !== "installing") return null;
+
+  const bytePercent = progress ? ratioPercent(progress.completedBytes, progress.totalBytes) : null;
+  const itemPercent = progress ? ratioPercent(progress.assetsCompleted, progress.totalAssets) : null;
+  // While an archive is being installed, the already-downloaded byte count can
+  // be 100% even though extraction is still in progress. Pack count is the
+  // honest meter for that phase; downloads remain byte-based.
+  const progressPercent = status === "installing"
+    ? itemPercent
+    : bytePercent ?? itemPercent;
+
+  return {
+    id: "primary",
+    kind: "asset-sync",
+    stage: progress?.phase ?? status,
+    detail: progress?.assetName || null,
+    progressPercent,
+    completedBytes: progress?.totalBytes ? progress.completedBytes : null,
+    totalBytes: progress?.totalBytes || null,
+    completedItems: progress?.totalAssets ? progress.assetsCompleted : null,
+    totalItems: progress?.totalAssets || null,
+  };
+}
+
+function integrityActivity(snapshot: LauncherSnapshot): GlobalActivity | null {
+  const progress = snapshot.integrityCheck;
+  if (!progress) return null;
+  const filePercent = ratioPercent(progress.hashedFiles, progress.totalFiles);
+  const bytePercent = ratioPercent(progress.hashedBytes, progress.totalBytes);
+  return {
+    id: "primary",
+    kind: "integrity",
+    stage: null,
+    detail: null,
+    progressPercent: filePercent ?? bytePercent,
+    completedBytes: progress.totalBytes ? progress.hashedBytes : null,
+    totalBytes: progress.totalBytes || null,
+    completedItems: progress.totalFiles ? progress.hashedFiles : null,
+    totalItems: progress.totalFiles || null,
+  };
+}
+
+function launchActivity(snapshot: LauncherSnapshot): GlobalActivity | null {
+  if (snapshot.phase !== "launching") return null;
+  return {
+    id: "primary",
+    kind: "launch",
+    stage: "launching",
+    detail: null,
+    progressPercent: null,
+    completedBytes: null,
+    totalBytes: null,
+    completedItems: null,
+    totalItems: null,
+  };
+}
+
+function updateActivity(snapshot: LauncherSnapshot): GlobalActivity | null {
+  const update = snapshot.launcherUpdate;
+  if (update.status !== "checking" && update.status !== "downloading") return null;
+  return {
+    id: "launcher-update",
+    kind: "launcher-update",
+    stage: update.status,
+    detail: update.availableVersion ? `v${update.availableVersion}` : null,
+    progressPercent: update.status === "downloading"
+      ? ratioPercent(update.progressPercent ?? 0, 100)
+      : null,
+    completedBytes: null,
+    totalBytes: null,
+    completedItems: null,
+    totalItems: null,
+  };
+}
+
+/**
+ * Derives homepage activity without introducing a second IPC state machine.
+ * The updater is independent from the main operation, so both can be visible.
+ */
+export function selectGlobalActivities(snapshot: LauncherSnapshot): GlobalActivity[] {
+  const primary = installActivity(snapshot)
+    ?? assetActivity(snapshot)
+    ?? integrityActivity(snapshot)
+    ?? launchActivity(snapshot);
+  const update = updateActivity(snapshot);
+  return [primary, update].filter((activity): activity is GlobalActivity => activity !== null);
+}
+

--- a/src/components/GlobalActivityCenter.tsx
+++ b/src/components/GlobalActivityCenter.tsx
@@ -1,0 +1,141 @@
+import {
+  Download,
+  PackageOpen,
+  RefreshCw,
+  Rocket,
+  ShieldCheck,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import type { AppLocale } from "../../shared/locale";
+import type { AssetSyncProgress, InstallProgress, LauncherSnapshot } from "../../shared/contracts";
+import {
+  selectGlobalActivities,
+  type GlobalActivity,
+} from "../activity-state";
+import { useI18n, type Copy } from "../i18n";
+
+interface GlobalActivityCenterProps {
+  snapshot: LauncherSnapshot;
+}
+
+function formatBytes(value: number, locale: AppLocale): string {
+  if (!Number.isFinite(value) || value <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const index = Math.min(units.length - 1, Math.floor(Math.log(value) / Math.log(1024)));
+  const scaled = value / (1024 ** index);
+  return `${new Intl.NumberFormat(locale === "fr" ? "fr-FR" : "en-US", {
+    maximumFractionDigits: index === 0 ? 0 : 1,
+    minimumFractionDigits: 0,
+  }).format(scaled)} ${units[index]}`;
+}
+
+function icon(activity: GlobalActivity): ReactNode {
+  switch (activity.kind) {
+    case "installation": return <PackageOpen size={22} />;
+    case "asset-sync": return <Download size={22} />;
+    case "integrity": return <ShieldCheck size={22} />;
+    case "launch": return <Rocket size={22} />;
+    case "launcher-update": return <RefreshCw size={22} />;
+  }
+}
+
+function title(activity: GlobalActivity, copy: Copy): string {
+  switch (activity.kind) {
+    case "installation": return copy.activity.installation;
+    case "asset-sync": return copy.activity.assets;
+    case "integrity": return copy.activity.integrity;
+    case "launch": return copy.activity.launch;
+    case "launcher-update": return copy.activity.launcherUpdate;
+  }
+}
+
+function stage(activity: GlobalActivity, copy: Copy): string {
+  if (activity.kind === "installation") {
+    const installStage = activity.stage as InstallProgress["phase"] | null;
+    return installStage ? copy.install.progressPhases[installStage] : copy.footer.installing;
+  }
+  if (activity.kind === "asset-sync") {
+    const assetStage = activity.stage as AssetSyncProgress["phase"] | null;
+    return assetStage ? copy.assets.status[assetStage] : copy.assets.updating;
+  }
+  if (activity.kind === "integrity") return copy.integrity.verifying;
+  if (activity.kind === "launch") return copy.footer.preparingClient;
+  if (activity.kind === "launcher-update") {
+    return activity.stage === "downloading" ? copy.update.downloading : copy.activity.checkingUpdate;
+  }
+  return copy.activity.working;
+}
+
+function detail(activity: GlobalActivity, copy: Copy): string {
+  if (activity.detail) return activity.detail;
+  switch (activity.kind) {
+    case "installation": return copy.activity.preparingFiles;
+    case "asset-sync": return copy.activity.checkingAssets;
+    case "integrity": return copy.activity.integrityDetail;
+    case "launch": return copy.activity.launchDetail;
+    case "launcher-update": return copy.activity.updateDetail;
+  }
+}
+
+function metrics(activity: GlobalActivity, copy: Copy, locale: AppLocale): string[] {
+  const values: string[] = [];
+  if (activity.completedItems !== null && activity.totalItems !== null) {
+    values.push(activity.kind === "asset-sync"
+      ? copy.activity.packs(activity.completedItems, activity.totalItems)
+      : copy.activity.files(activity.completedItems, activity.totalItems));
+  }
+  if (activity.completedBytes !== null && activity.totalBytes !== null) {
+    values.push(`${formatBytes(activity.completedBytes, locale)} / ${formatBytes(activity.totalBytes, locale)}`);
+  }
+  return values;
+}
+
+export function GlobalActivityCenter({ snapshot }: GlobalActivityCenterProps) {
+  const { locale, copy } = useI18n();
+  const activities = selectGlobalActivities(snapshot);
+  if (activities.length === 0) return null;
+
+  return (
+    <section className="activity-center" aria-label={copy.activity.regionLabel}>
+      {activities.map((activity) => {
+        const activityTitle = title(activity, copy);
+        const activityStage = stage(activity, copy);
+        const activityMetrics = metrics(activity, copy, locale);
+        const percent = activity.progressPercent;
+        const roundedPercent = percent === null ? null : Math.round(percent);
+        return (
+          <article className="activity-card" key={activity.id}>
+            <div className="activity-card__icon" aria-hidden="true">{icon(activity)}</div>
+            <div className="activity-card__body">
+              <div className="activity-card__heading" aria-live="polite" aria-atomic="true">
+                <span>{copy.activity.eyebrow} · {activityStage}</span>
+                <strong>{activityTitle}</strong>
+              </div>
+              <small className="activity-card__detail" title={detail(activity, copy)}>
+                {detail(activity, copy)}
+              </small>
+              <div
+                className={`activity-card__track${roundedPercent === null ? " is-indeterminate" : ""}`}
+                role="progressbar"
+                aria-label={copy.activity.progress(activityTitle)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                {...(roundedPercent === null ? {} : { "aria-valuenow": roundedPercent })}
+              >
+                <i style={roundedPercent === null ? undefined : { width: `${percent}%` }} />
+              </div>
+              {activityMetrics.length > 0 && (
+                <div className="activity-card__metrics" aria-hidden="true">
+                  {activityMetrics.map((value) => <span key={value}>{value}</span>)}
+                </div>
+              )}
+            </div>
+            <strong className="activity-card__percent" aria-hidden="true">
+              {roundedPercent === null ? "•••" : `${roundedPercent}%`}
+            </strong>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/LauncherFooter.tsx
+++ b/src/components/LauncherFooter.tsx
@@ -17,6 +17,26 @@ function statusCopy(snapshot: LauncherSnapshot, copy: Copy): { label: string; de
       detail: snapshot.gamePid ? `${copy.footer.process} ${snapshot.gamePid}` : copy.footer.activeProcess,
     };
   }
+  const assetSyncActive = snapshot.assetSync.status === "checking"
+    || snapshot.assetSync.status === "downloading"
+    || snapshot.assetSync.status === "installing";
+  if (snapshot.phase !== "installing" && assetSyncActive) {
+    const progress = snapshot.assetSync.progress;
+    const bytePercent = progress && progress.totalBytes > 0
+      ? (progress.completedBytes / progress.totalBytes) * 100
+      : null;
+    const packPercent = progress && progress.totalAssets > 0
+      ? (progress.assetsCompleted / progress.totalAssets) * 100
+      : null;
+    const percent = snapshot.assetSync.status === "installing"
+      ? packPercent
+      : bytePercent ?? packPercent;
+    const status = copy.assets.status[snapshot.assetSync.status];
+    const detail = percent === null
+      ? status
+      : `${status} — ${Math.min(100, Math.max(0, Math.round(percent)))}%`;
+    return { label: copy.assets.updating, detail };
+  }
   if (snapshot.phase === "launching") {
     const assetProgress = snapshot.assetSync.progress;
     if (assetProgress && assetProgress.totalBytes > 0) {

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -17,16 +17,13 @@ export function UpdateBanner({ snapshot, busy, onDownload, onInstall }: UpdateBa
 
   const visible =
     update.status === "update-available"
-    || update.status === "downloading"
     || update.status === "downloaded"
     || (update.status === "error" && update.error !== null);
   if (!visible || dismissed || !update.availableVersion) return null;
 
   const version = `v${update.availableVersion}`;
   const label =
-    update.status === "downloading"
-      ? copy.update.downloading
-      : update.status === "downloaded"
+    update.status === "downloaded"
         ? copy.update.restart
         : update.status === "error"
           ? copy.update.failed
@@ -36,9 +33,7 @@ export function UpdateBanner({ snapshot, busy, onDownload, onInstall }: UpdateBa
       ? update.error ?? ""
       : update.status === "downloaded"
         ? copy.update.restartDetail
-        : update.status === "downloading"
-          ? version
-          : copy.update.availableDetail;
+        : copy.update.availableDetail;
 
   return (
     <aside className="update-banner" role="status">
@@ -46,11 +41,6 @@ export function UpdateBanner({ snapshot, busy, onDownload, onInstall }: UpdateBa
       <div className="update-banner__text">
         <strong>{label}</strong>
         <small title={detail}>{detail}</small>
-        {update.status === "downloading" && (
-          <span className="update-banner__progress">
-            <i style={{ width: `${update.progressPercent ?? 0}%` }} />
-          </span>
-        )}
       </div>
       {update.status === "update-available" && (
         <button type="button" disabled={busy} onClick={onDownload}>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -122,6 +122,25 @@ export interface Copy {
     progressPhases: Record<"scanning" | "copying" | "verifying" | "configuring" | "finalizing", string>;
     progressFiles: Record<"scanning" | "verifying" | "configuring" | "finalizing", string>;
   };
+  activity: {
+    regionLabel: string;
+    eyebrow: string;
+    installation: string;
+    assets: string;
+    integrity: string;
+    launch: string;
+    launcherUpdate: string;
+    checkingUpdate: string;
+    checkingAssets: string;
+    preparingFiles: string;
+    integrityDetail: string;
+    launchDetail: string;
+    updateDetail: string;
+    working: string;
+    files: (completed: number, total: number) => string;
+    packs: (completed: number, total: number) => string;
+    progress: (operation: string) => string;
+  };
   integrity: {
     verifying: string;
   };
@@ -262,6 +281,25 @@ const COPY: Record<AppLocale, Copy> = {
         configuring: "Applying ROTK client configuration",
         finalizing: "Atomic finalization",
       },
+    },
+    activity: {
+      regionLabel: "Launcher operations",
+      eyebrow: "OPERATION IN PROGRESS",
+      installation: "ROTK CLIENT INSTALLATION",
+      assets: "ROTK GAME ASSETS",
+      integrity: "GAME FILE VERIFICATION",
+      launch: "GAME LAUNCH",
+      launcherUpdate: "LAUNCHER UPDATE",
+      checkingUpdate: "CHECKING FOR UPDATE",
+      checkingAssets: "Checking the official asset feed",
+      preparingFiles: "Preparing the H1Z1 client files",
+      integrityDetail: "Checking every game file before launch",
+      launchDetail: "Preparing the secure game session",
+      updateDetail: "Contacting the official release feed",
+      working: "WORKING",
+      files: (completed, total) => `${completed} / ${total} files`,
+      packs: (completed, total) => `${completed} / ${total} packs`,
+      progress: (operation) => `${operation} progress`,
     },
     integrity: {
       verifying: "VERIFYING GAME FILES",
@@ -413,6 +451,25 @@ const COPY: Record<AppLocale, Copy> = {
         configuring: "Application du client ROTK",
         finalizing: "Finalisation atomique",
       },
+    },
+    activity: {
+      regionLabel: "Opérations du launcher",
+      eyebrow: "OPÉRATION EN COURS",
+      installation: "INSTALLATION DU CLIENT ROTK",
+      assets: "ASSETS DU JEU ROTK",
+      integrity: "VÉRIFICATION DES FICHIERS",
+      launch: "LANCEMENT DU JEU",
+      launcherUpdate: "MISE À JOUR DU LAUNCHER",
+      checkingUpdate: "RECHERCHE DE MISE À JOUR",
+      checkingAssets: "Vérification du flux officiel des assets",
+      preparingFiles: "Préparation des fichiers du client H1Z1",
+      integrityDetail: "Vérification de chaque fichier avant le lancement",
+      launchDetail: "Préparation de la session de jeu sécurisée",
+      updateDetail: "Connexion au flux officiel des releases",
+      working: "EN COURS",
+      files: (completed, total) => `${completed} / ${total} fichiers`,
+      packs: (completed, total) => `${completed} / ${total} packs`,
+      progress: (operation) => `Progression de l’opération ${operation}`,
     },
     integrity: {
       verifying: "VÉRIFICATION DES FICHIERS DU JEU",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -528,6 +528,165 @@ button:focus-visible {
   color: var(--ink);
 }
 
+.activity-center {
+  position: absolute;
+  z-index: 15;
+  top: 88px;
+  left: clamp(28px, 4vw, 58px);
+  width: min(720px, calc(100vw - 300px));
+  display: grid;
+  gap: 9px;
+  pointer-events: none;
+}
+
+.activity-card {
+  position: relative;
+  min-height: 112px;
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 17px 21px 16px 17px;
+  overflow: hidden;
+  border: 1px solid rgba(238, 236, 228, 0.2);
+  border-left: 4px solid var(--signal);
+  background:
+    linear-gradient(100deg, rgba(230, 64, 52, 0.09), transparent 45%),
+    rgba(12, 12, 11, 0.94);
+  box-shadow: 0 20px 55px rgba(0, 0, 0, 0.44);
+  backdrop-filter: blur(14px);
+}
+
+.activity-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(115deg, transparent 56%, rgba(255, 255, 255, 0.025));
+}
+
+.activity-card__icon {
+  position: relative;
+  z-index: 1;
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(230, 64, 52, 0.34);
+  background: rgba(230, 64, 52, 0.1);
+  color: var(--signal);
+}
+
+.activity-card__body {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.activity-card__heading {
+  display: flex;
+  align-items: baseline;
+  gap: 11px;
+  min-width: 0;
+}
+
+.activity-card__heading span {
+  flex: 0 0 auto;
+  color: var(--signal);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+}
+
+.activity-card__heading strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--paper);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-card__detail {
+  display: block;
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--paper-dim);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.035em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-card__track {
+  position: relative;
+  height: 6px;
+  margin-top: 12px;
+  overflow: hidden;
+  background: rgba(238, 236, 228, 0.13);
+}
+
+.activity-card__track i {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--signal-dark), var(--signal), #f06c62);
+  box-shadow: 0 0 18px rgba(230, 64, 52, 0.5);
+  transition: width 140ms linear;
+}
+
+.activity-card__track.is-indeterminate i {
+  width: 38%;
+  animation: activity-indeterminate 1.25s ease-in-out infinite;
+}
+
+.activity-card__metrics {
+  display: flex;
+  gap: 17px;
+  margin-top: 6px;
+  color: var(--muted);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+}
+
+.activity-card__metrics span + span {
+  position: relative;
+}
+
+.activity-card__metrics span + span::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -9px;
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.activity-card__percent {
+  position: relative;
+  z-index: 1;
+  min-width: 54px;
+  color: var(--paper);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 29px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-align: right;
+}
+
+@keyframes activity-indeterminate {
+  0% { transform: translateX(-105%); }
+  55% { transform: translateX(115%); }
+  100% { transform: translateX(285%); }
+}
+
 .launcher-footer {
   position: absolute;
   z-index: 12;
@@ -1468,6 +1627,14 @@ button:focus-visible {
 }
 
 @media (max-width: 1160px) {
+  .activity-center {
+    width: min(650px, calc(100vw - 250px));
+  }
+
+  .activity-card__heading span {
+    display: none;
+  }
+
   .launcher-footer {
     grid-template-columns: minmax(300px, 1fr) 245px 104px 220px;
   }

--- a/tests/activity-state.test.ts
+++ b/tests/activity-state.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import type { LauncherSnapshot } from "../shared/contracts.js";
+import { selectGlobalActivities } from "../src/activity-state.js";
+
+function snapshot(overrides: Partial<LauncherSnapshot> = {}): LauncherSnapshot {
+  return {
+    appVersion: "0.8.0",
+    phase: "ready",
+    selection: {
+      sourceRoot: "C:\\H1Z1",
+      destinationRoot: null,
+      sourceKind: "direct",
+      sourceDetected: false,
+      destinationRecommended: false,
+    },
+    installationRoot: "C:\\H1Z1",
+    updates: [],
+    runtime: {
+      environment: "development",
+      label: "ROTK GAME 2",
+      websiteOrigin: "https://rotk.app",
+    },
+    playerIdentity: { configured: true, playerKey: "0".repeat(32) },
+    launcherUpdate: {
+      status: "idle",
+      availableVersion: null,
+      progressPercent: null,
+      error: null,
+    },
+    assetSync: {
+      enabled: true,
+      status: "up-to-date",
+      packVersion: "1.1.0",
+      lastSyncAt: null,
+      progress: null,
+      warning: null,
+    },
+    integrityCheck: null,
+    progress: null,
+    error: null,
+    gamePid: null,
+    canPlay: true,
+    ...overrides,
+  };
+}
+
+describe("homepage activity selector", () => {
+  it.each(["unconfigured", "source-selected", "destination-selected", "ready", "running"] as const)(
+    "stays hidden while %s is idle",
+    (phase) => expect(selectGlobalActivities(snapshot({ phase }))).toEqual([]),
+  );
+
+  it("shows installation immediately, before the first progress event", () => {
+    expect(selectGlobalActivities(snapshot({ phase: "installing" }))).toMatchObject([
+      { kind: "installation", stage: null, progressPercent: null },
+    ]);
+  });
+
+  it("uses bytes for client copy progress and clamps overrun", () => {
+    const [activity] = selectGlobalActivities(snapshot({
+      phase: "installing",
+      progress: {
+        phase: "copying",
+        completedBytes: 125,
+        totalBytes: 100,
+        filesCompleted: 2,
+        totalFiles: 10,
+        currentFile: "H1Z1.exe",
+      },
+    }));
+    expect(activity).toMatchObject({
+      kind: "installation",
+      stage: "copying",
+      detail: "H1Z1.exe",
+      progressPercent: 100,
+    });
+  });
+
+  it("shows manual or post-install asset downloads while the launcher is ready", () => {
+    const [activity] = selectGlobalActivities(snapshot({
+      assetSync: {
+        enabled: true,
+        status: "downloading",
+        packVersion: null,
+        lastSyncAt: null,
+        warning: null,
+        progress: {
+          phase: "downloading",
+          assetName: "assets_x64_1.zip",
+          assetsCompleted: 2,
+          totalAssets: 7,
+          completedBytes: 25,
+          totalBytes: 100,
+        },
+      },
+    }));
+    expect(activity).toMatchObject({
+      kind: "asset-sync",
+      detail: "assets_x64_1.zip",
+      progressPercent: 25,
+      completedItems: 2,
+      totalItems: 7,
+    });
+  });
+
+  it("uses completed packs rather than downloaded bytes during extraction", () => {
+    const [activity] = selectGlobalActivities(snapshot({
+      assetSync: {
+        enabled: true,
+        status: "installing",
+        packVersion: null,
+        lastSyncAt: null,
+        warning: null,
+        progress: {
+          phase: "installing",
+          assetName: "assets_x64_1.zip",
+          assetsCompleted: 3,
+          totalAssets: 6,
+          completedBytes: 100,
+          totalBytes: 100,
+        },
+      },
+    }));
+    expect(activity.progressPercent).toBe(50);
+  });
+
+  it("keeps checking states visible without inventing a percentage", () => {
+    const [activity] = selectGlobalActivities(snapshot({
+      assetSync: {
+        enabled: true,
+        status: "checking",
+        packVersion: null,
+        lastSyncAt: null,
+        warning: null,
+        progress: null,
+      },
+    }));
+    expect(activity).toMatchObject({ kind: "asset-sync", progressPercent: null });
+  });
+
+  it("prioritizes asset work over integrity and generic launch", () => {
+    const [activity] = selectGlobalActivities(snapshot({
+      phase: "launching",
+      assetSync: {
+        enabled: true,
+        status: "checking",
+        packVersion: "1.1.0",
+        lastSyncAt: null,
+        warning: null,
+        progress: null,
+      },
+      integrityCheck: { hashedFiles: 5, totalFiles: 10, hashedBytes: 50, totalBytes: 100 },
+    }));
+    expect(activity.kind).toBe("asset-sync");
+  });
+
+  it("shows integrity progress before falling back to generic launch", () => {
+    const [integrity] = selectGlobalActivities(snapshot({
+      phase: "launching",
+      integrityCheck: { hashedFiles: 3, totalFiles: 4, hashedBytes: 20, totalBytes: 100 },
+    }));
+    expect(integrity).toMatchObject({ kind: "integrity", progressPercent: 75 });
+
+    const [launch] = selectGlobalActivities(snapshot({ phase: "launching" }));
+    expect(launch).toMatchObject({ kind: "launch", progressPercent: null });
+  });
+
+  it("keeps the independent launcher update visible beside core work", () => {
+    const activities = selectGlobalActivities(snapshot({
+      phase: "launching",
+      launcherUpdate: {
+        status: "downloading",
+        availableVersion: "0.9.0",
+        progressPercent: 42.4,
+        error: null,
+      },
+    }));
+    expect(activities).toHaveLength(2);
+    expect(activities[0].kind).toBe("launch");
+    expect(activities[1]).toMatchObject({
+      kind: "launcher-update",
+      detail: "v0.9.0",
+      progressPercent: 42.4,
+    });
+  });
+});

--- a/tests/client-config.test.ts
+++ b/tests/client-config.test.ts
@@ -70,7 +70,7 @@ describe("ClientConfig synchronization", () => {
     expect(() => synchronizeClientConfig(
       original,
       runtime,
-      `http://51.255.160.224/rest/auth/session/create?sessionid=${authKey}`,
+      `http://203.0.113.10/rest/auth/session/create?sessionid=${authKey}`,
     )).toThrow(
       "Invalid local ROTK session gateway URL",
     );

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -3,18 +3,19 @@ import { gameLauncherInternals } from "../electron/services/game-launcher.js";
 import { DEFAULT_RUNTIME_CONFIG, serverList } from "../electron/services/runtime-config.js";
 
 describe("public ROTK runtime", () => {
-  it("targets the OVH gateway and every public login listener", () => {
+  it("targets the GAME 2 gateway and every public login listener", () => {
     expect(DEFAULT_RUNTIME_CONFIG.environment).toBe("production");
-    expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://51.255.160.224");
+    expect(DEFAULT_RUNTIME_CONFIG.label).toBe("ROTK GAME 2");
+    expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://162.19.94.95");
     expect(DEFAULT_RUNTIME_CONFIG.voiceGrantOrigin).toBe(
       "https://vps-c717eb9e.vps.ovh.net",
     );
     expect(serverList(DEFAULT_RUNTIME_CONFIG)).toBe(
-      "51.255.160.224:20042;51.255.160.224:20043;51.255.160.224:20044;51.255.160.224:20045",
+      "162.19.94.95:20042;162.19.94.95:20043;162.19.94.95:20044;162.19.94.95:20045",
     );
   });
 
-  it("passes only the short ticket and bounded OVH endpoints to H1Z1", () => {
+  it("passes only the short ticket and bounded GAME 2 endpoints to H1Z1", () => {
     const durableKey = "0123456789abcdef0123456789abcdef";
     const launchTicket = "T".repeat(43);
     const args = gameLauncherInternals.buildLaunchArguments(
@@ -28,7 +29,7 @@ describe("public ROTK runtime", () => {
     expect(args).toContain(`sessionid=${launchTicket}`);
     expect(args.join(" ")).not.toContain(durableKey);
     expect(args).toContain(
-      `server=51.255.160.224:20042;51.255.160.224:20043;51.255.160.224:20044;51.255.160.224:20045`,
+      `server=162.19.94.95:20042;162.19.94.95:20043;162.19.94.95:20044;162.19.94.95:20045`,
     );
     expect(args).toContain(
       "SteamGatewayUrl=http://127.0.0.1:49152/rest/auth/session/create",
@@ -36,9 +37,9 @@ describe("public ROTK runtime", () => {
     expect(args).toContain(
       "VivoxGrantUrl=https://vps-c717eb9e.vps.ovh.net",
     );
-    expect(args).toContain("CommandQueue:motd_uri=http://51.255.160.224/");
+    expect(args).toContain("CommandQueue:motd_uri=http://162.19.94.95/");
     expect(args.some((argument) => (
-      argument.includes("51.255.160.224/rest/auth/session/create")
+      argument.includes("162.19.94.95/rest/auth/session/create")
     ))).toBe(false);
     expect(args.join(" ")).not.toMatch(
       /token.?key|private.?key|client.?secret|password/i,


### PR DESCRIPTION
## Mise à jour
- pointe le launcher vers GAME 2 (162.19.94.95)
- reconstruit et valide le proxy Vivox avant dev/distribution
- affiche toute activité de téléchargement/synchronisation directement sur l’accueil
- aligne package.json et package-lock.json sur 9.0.0

## Validation locale
- npm ci: PASS
- Vivox proxy/runtime: PASS
- typecheck: PASS
- 148 tests: PASS
- build renderer/electron: PASS
- dist:dir Windows: PASS
- dépendances de production: 0 vulnérabilité npm audit

Solo est désactivé côté GAME 2 pour cette mise en ligne initiale.