### PR TITLE
fix(release): publish GAME 2 launcher as v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "9.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "9.0.0",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "9.0.0",
+  "version": "1.0.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
Correction de version : la prochaine release publique est v1.0.0, pas v9.0.0.

- package.json: 1.0.0
- package-lock.json racine: 1.0.0
- proxy Vivox vérifié
- 148 tests locaux: PASS
- build Windows non signé: PASS
- dépendances production: 0 vulnérabilité

La release v9.0.0 erronée a été immédiatement remise en draft ; ses seuls téléchargements étaient ceux de notre vérification.