### PR TITLE
feat: point the launcher at the self-hosted API and the moved Gateway

### DIFF
--- a/electron/services/runtime-config.ts
+++ b/electron/services/runtime-config.ts
@@ -20,14 +20,16 @@ export interface RuntimeConfig {
 export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   environment: "production",
   label: "ROTK GAME 2",
-  gatewayOrigin: "http://162.19.94.95",
+  // The Gateway moved off :80 so Nginx can own it for the website. Nothing in
+  // the client requires 80 — it only ever learns this URL from here, and the
+  // port travels with it into every derived value below.
+  gatewayOrigin: "http://162.19.94.95:8080",
   voiceGrantOrigin: "https://vps-c717eb9e.vps.ovh.net",
   loginHost: "162.19.94.95",
   loginPorts: [20042, 20043, 20044, 20045],
   websiteOrigin: "https://rotk.app",
-  launchTicketUrl: "https://europe-west1-rotk-project.cloudfunctions.net/createLaunchTicket",
-  attestationChallengeUrl:
-    "https://europe-west1-rotk-project.cloudfunctions.net/beginLauncherAttestation",
+  launchTicketUrl: "https://rotk.app/api/launcher/ticket",
+  attestationChallengeUrl: "https://rotk.app/api/launcher/attestation/challenge",
 };
 
 export function serverList(runtime: RuntimeConfig): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -6,7 +6,9 @@ describe("public ROTK runtime", () => {
   it("targets the GAME 2 gateway and every public login listener", () => {
     expect(DEFAULT_RUNTIME_CONFIG.environment).toBe("production");
     expect(DEFAULT_RUNTIME_CONFIG.label).toBe("ROTK GAME 2");
-    expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://162.19.94.95");
+    // The Gateway moved off :80 so Nginx can own it for the website; the port
+    // must travel into every URL the client is handed.
+    expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://162.19.94.95:8080");
     expect(DEFAULT_RUNTIME_CONFIG.voiceGrantOrigin).toBe(
       "https://vps-c717eb9e.vps.ovh.net",
     );
@@ -37,9 +39,9 @@ describe("public ROTK runtime", () => {
     expect(args).toContain(
       "VivoxGrantUrl=https://vps-c717eb9e.vps.ovh.net",
     );
-    expect(args).toContain("CommandQueue:motd_uri=http://162.19.94.95/");
+    expect(args).toContain("CommandQueue:motd_uri=http://162.19.94.95:8080/");
     expect(args.some((argument) => (
-      argument.includes("162.19.94.95/rest/auth/session/create")
+      argument.includes("162.19.94.95:8080/rest/auth/session/create")
     ))).toBe(false);
     expect(args.join(" ")).not.toMatch(
       /token.?key|private.?key|client.?secret|password/i,


### PR DESCRIPTION
The two compiled URLs move off Cloud Functions to https://rotk.app/api/launcher/..., and gatewayOrigin gains the Gateway's new port 8080 — the breaking launcher release the migration plan calls for. Version 1.1.0, package-lock now in step with package.json (the bump had left it at the old version).

Rebased onto main to absorb the v1.0.0 release-version correction; the conflict was the version line, resolved to 1.1.0.

Server side counterpart: MzKaxD/returnoftheking feat/self-hosted-web-migration (ticket route speaks this launcher's exact parser contract, proved against its regexes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)