### PR TITLE
fix(launch): name the refusal for an account with no game identity

### DIFF
--- a/electron/services/launch-ticket.ts
+++ b/electron/services/launch-ticket.ts
@@ -164,6 +164,14 @@ function serviceError(status: number, value: unknown): Error {
         : `This ROTK account is permanently banned.${reason}`,
     );
   }
+  // The account exists and the key is good, but the service holds no game
+  // identity to put in a ticket. Naming that is the difference between a player
+  // who knows to finish signing in and one who reinstalls the game twice.
+  if (errorCode === "account_not_ready") {
+    return new Error(
+      "This ROTK account is not ready to play yet. Sign in on the ROTK website, then try again.",
+    );
+  }
   if (status === 401 || errorCode === "invalid_credentials") {
     return new Error("The ROTK launcher key was rejected");
   }

--- a/tests/launch-ticket.test.ts
+++ b/tests/launch-ticket.test.ts
@@ -91,6 +91,13 @@ describe("ROTK launch ticket client", () => {
       .rejects.toThrow("The ROTK launcher key was rejected");
   });
 
+  it("names an account the service holds no game identity for", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: "account_not_ready" }, 403)) as typeof fetch;
+
+    await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
+      .rejects.toThrow("This ROTK account is not ready to play yet");
+  });
+
   it("rejects malformed identity data even after HTTP 200", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({
       ...validResponse,


### PR DESCRIPTION
`serviceError` ne connaît pas `account_not_ready`, donc ce code tombe dans le fourre-tout final et le joueur lit « The ROTK account service refused the launch request » — le message que cette fonction renvoie quand elle ne reconnaît rien. Un compte à qui il manque seulement son identité de jeu est donc annoncé comme rejeté par le service, sans rien sur quoi agir.

C'est ce message qu'un joueur fraîchement inscrit a remonté. La cause serveur est corrigée dans MzKaxD/returnoftheking#125 (l'inscription ne posait jamais de `game_account_guid`) ; cette PR ne fait que nommer le refus, pour que le prochain compte dans cet état — un slot admin en cours de provisionnement, par exemple — dise ce qu'il en est.

Aucun changement de comportement : même échec, même point d'échec, message différent. Test unitaire ajouté ; 162 tests et `npm run typecheck` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
