### PR TITLE
feat(launcher): mandatory update + HWID, and don't swallow attestation failures

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -54,6 +54,7 @@ import {
   validateInstalledClient,
   type AttestationOutcome,
 } from "./services/game-launcher.js";
+import { collectHwid } from "./services/machine-identity.js";
 import { classifyClientSource, validateInstallDestination } from "./services/path-policy.js";
 import { locateSteamClient } from "./services/steam-locator.js";
 import {
@@ -127,6 +128,9 @@ let destinationRecommended = false;
 let progress: LauncherSnapshot["progress"] = null;
 let updates: LauncherSnapshot["updates"] = [];
 let lastErrorRaw: string | null = null;
+// Set when the server refuses a launch for launcher_update_required: the update
+// becomes mandatory (Play is blocked) until a newer launcher is installed.
+let updateRequired = false;
 let gamePid: number | null = null;
 let currentLocale: AppLocale = "en";
 let playerKeys: PlayerKeySet = {};
@@ -400,11 +404,14 @@ async function snapshot(): Promise<LauncherSnapshot> {
     progress,
     error: lastErrorRaw ? localizeServiceError(lastErrorRaw, currentLocale) : null,
     gamePid,
+    updateRequired,
     canPlay:
       phase === "ready"
       && configuredRoot !== null
       && activeKey() !== null
-      && !gameLauncher.isRunning(),
+      && !gameLauncher.isRunning()
+      // A mandatory update blocks Play until a newer launcher is installed.
+      && !updateRequired,
   };
 }
 
@@ -777,6 +784,10 @@ function registerIpc(): void {
           bundledVivoxProxyPath: resolveBundledVivoxProxyPath(),
           bundledVivoxRuntimePath: resolveBundledVivoxRuntimePath(),
           attest: () => attestInstallation(launchCredential.playerKey, launchRuntime),
+          launcherVersion: app.getVersion(),
+          // Best-effort hardware fingerprint; the server hashes it. A failure
+          // must never block a launch, so it degrades to no HWID signal.
+          hwid: await collectHwid().catch(() => ({})),
           onExit: () => {
             gamePid = null;
             phase = "ready";
@@ -790,8 +801,13 @@ function registerIpc(): void {
         return { ok: true, value: { pid } };
       } catch (error) {
         const result = operationError<{ pid: number }>(error);
-        // Keep Play retryable after a transient launch failure while retaining
-        // the concrete error in the snapshot.
+        // A version refusal makes the update mandatory: block Play and kick the
+        // updater so the newer launcher downloads. Any other failure stays
+        // retryable, so it must not set the flag.
+        if ((error as { code?: string })?.code === "launcher_update_required") {
+          updateRequired = true;
+          void launcherUpdate.check().catch(() => undefined);
+        }
         phase = "ready";
         await broadcastSnapshot();
         if (quitWhenGameExits && !mainWindow) app.quit();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -49,7 +49,11 @@ import {
 } from "./constants.js";
 import { ConfigStore } from "./services/config-store.js";
 import { adoptExistingClient, installClient } from "./services/installer.js";
-import { GameLauncher, validateInstalledClient } from "./services/game-launcher.js";
+import {
+  GameLauncher,
+  validateInstalledClient,
+  type AttestationOutcome,
+} from "./services/game-launcher.js";
 import { classifyClientSource, validateInstallDestination } from "./services/path-policy.js";
 import { locateSteamClient } from "./services/steam-locator.js";
 import {
@@ -78,6 +82,7 @@ import {
   readLauncherOverrides,
 } from "./services/base-manifest.js";
 import {
+  AttestationUnavailableError,
   buildAttestationResult,
   measureInstallation,
   requestAttestationChallenge,
@@ -283,14 +288,14 @@ async function runAssetSync(mode: "sync" | "verify", soft: boolean): Promise<Ope
 async function attestInstallation(
   playerKey: string,
   runtime: RuntimeConfig,
-): Promise<unknown | null> {
+): Promise<AttestationOutcome> {
   const root = await installationRoot();
-  if (!root) return null;
+  if (!root) return { status: "not-applicable" };
   const userDataDirectory = app.getPath("userData");
   const launcherVersion = app.getVersion();
   try {
     const marker = await readInstallationMarker(root);
-    if (!marker) return null;
+    if (!marker) return { status: "not-applicable" };
 
     const challenge = await requestAttestationChallenge(
       playerKey,
@@ -337,15 +342,22 @@ async function attestInstallation(
         `Integrity attestation found ${measurement.deviations.length} deviation(s); reporting them.`,
       );
     }
-    return buildAttestationResult(challenge, measurement, launcherVersion);
+    return { status: "attested", block: buildAttestationResult(challenge, measurement, launcherVersion) };
   } catch (error) {
     attestationProgress = null;
-    // A challenge or manifest we cannot obtain is reported as "no attestation";
-    // the backend applies its enforcement policy to that.
-    console.warn("Integrity attestation could not complete", {
-      message: error instanceof Error ? error.message : "unknown",
-    });
-    return null;
+    // No policy published / attestation unconfigured: it does not apply, and
+    // the launch proceeds silently exactly as before enforcement existed.
+    if (error instanceof AttestationUnavailableError && error.notApplicable) {
+      return { status: "not-applicable" };
+    }
+    // A challenge or manifest we could not obtain, or files we could not read:
+    // attestation should have run and did not. Carry the reason so a launch the
+    // backend then blocks can say why, instead of blaming the launcher version.
+    const reason = error instanceof Error && error.message
+      ? error.message.replace(/[.]?\s*$/, ".")
+      : "the integrity service could not be reached.";
+    console.warn("Integrity attestation could not complete", { message: reason });
+    return { status: "unavailable", reason };
   }
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -801,9 +801,11 @@ function registerIpc(): void {
         return { ok: true, value: { pid } };
       } catch (error) {
         const result = operationError<{ pid: number }>(error);
-        // A version refusal makes the update mandatory: block Play and kick the
-        // updater so the newer launcher downloads. Any other failure stays
-        // retryable, so it must not set the flag.
+        // A version refusal makes the update mandatory: block Play, and CHECK
+        // for the update (metadata only — autoDownload is false) so the modal
+        // can show that a new version exists. Nothing is downloaded here; the
+        // installer is fetched only when the player consents via the update
+        // action. Any other failure stays retryable, so it must not set the flag.
         if ((error as { code?: string })?.code === "launcher_update_required") {
           updateRequired = true;
           void launcherUpdate.check().catch(() => undefined);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,7 @@ import {
   type AttestationOutcome,
 } from "./services/game-launcher.js";
 import { collectHwid } from "./services/machine-identity.js";
+import { collectTpmProof } from "./services/tpm-identity.js";
 import { classifyClientSource, validateInstallDestination } from "./services/path-policy.js";
 import { locateSteamClient } from "./services/steam-locator.js";
 import {
@@ -346,7 +347,16 @@ async function attestInstallation(
         `Integrity attestation found ${measurement.deviations.length} deviation(s); reporting them.`,
       );
     }
-    return { status: "attested", block: buildAttestationResult(challenge, measurement, launcherVersion) };
+    // Sign the challengeId with the TPM-backed key when the machine has one;
+    // null when it does not, and the launch proceeds without it. Signing the
+    // (single-use) challengeId rather than the nonce lets the server verify with
+    // a value it already holds, while the single-use challenge stops replay. The
+    // server decides (behind its own flag) whether a missing proof is acceptable.
+    const tpmProof = await collectTpmProof(challenge.challengeId).catch(() => null);
+    return {
+      status: "attested",
+      block: buildAttestationResult(challenge, measurement, launcherVersion, tpmProof),
+    };
   } catch (error) {
     attestationProgress = null;
     // No policy published / attestation unconfigured: it does not apply, and

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -17,6 +17,21 @@ import {
 } from "./launch-ticket.js";
 import { deployVivoxCompatibility } from "./vivox-client.js";
 
+/**
+ * What one attestation attempt produced.
+ * - `attested`: a block to carry with the ticket request.
+ * - `not-applicable`: the server has no attestation to run (no policy yet, or
+ *   unconfigured). Launch as usual — the ticket route stays the authority.
+ * - `unavailable`: attestation should have run but could not (service
+ *   unreachable, files unreadable, malformed response). No block is sent, and
+ *   if enforcement then blocks the launch, the reason explains why instead of
+ *   the ticket route's opaque "update the launcher".
+ */
+export type AttestationOutcome =
+  | { readonly status: "attested"; readonly block: unknown }
+  | { readonly status: "not-applicable" }
+  | { readonly status: "unavailable"; readonly reason: string };
+
 export interface LaunchRequest {
   config: LauncherConfig;
   identity: PlayerIdentity;
@@ -26,13 +41,28 @@ export interface LaunchRequest {
   bundledVivoxProxyPath: string;
   bundledVivoxRuntimePath: string;
   /**
-   * Integrity attestation hook. Resolves to the block the ticket request
-   * carries, or null when attestation cannot run (no policy published yet, or
-   * the launcher is configured without it). The backend decides what an absent
-   * attestation means — the launcher never self-exempts.
+   * Integrity attestation hook. The launcher never self-exempts: it reports
+   * what it observed and lets the backend decide what an absent attestation
+   * means.
    */
-  attest?: () => Promise<unknown | null>;
+  attest?: () => Promise<AttestationOutcome>;
   onExit(exitCode: number | null): void;
+}
+
+/**
+ * Turn an attestation outcome into the ticket request's attestation options. A
+ * clean measurement carries its block; a not-applicable one carries nothing and
+ * says nothing; an unavailable one carries nothing but records why, so a launch
+ * the server then refuses under enforcement can name the real cause.
+ */
+function ticketAttestationOptions(
+  outcome: AttestationOutcome,
+): { attestation?: unknown; attestationUnavailableReason?: string } {
+  if (outcome.status === "attested") return { attestation: outcome.block };
+  if (outcome.status === "unavailable") {
+    return { attestationUnavailableReason: outcome.reason };
+  }
+  return {};
 }
 
 async function validateMarker(installation: InstalledClientConfig): Promise<void> {
@@ -183,14 +213,16 @@ export class GameLauncher {
 
     // Integrity attestation runs before the ticket exists: the whole point is
     // that a tampered installation never obtains one.
-    const attestation = request.attest ? await request.attest() : null;
+    const outcome = request.attest
+      ? await request.attest()
+      : { status: "not-applicable" } as const;
 
     // The durable website key reaches only the HTTPS account service. H1Z1
     // receives a short ticket and the Steam identity authenticated by it.
     let launchIdentity = await createLaunchTicket(
       request.identity.playerKey,
       request.runtime.launchTicketUrl,
-      { attestation },
+      ticketAttestationOptions(outcome),
     );
     let sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
 
@@ -211,11 +243,13 @@ export class GameLauncher {
         await sessionGateway.close().catch(() => undefined);
         // A fresh ticket needs a fresh attestation: the first challenge was
         // consumed by the request above and is not replayable.
-        const refreshedAttestation = request.attest ? await request.attest() : null;
+        const refreshed = request.attest
+          ? await request.attest()
+          : { status: "not-applicable" } as const;
         launchIdentity = await createLaunchTicket(
           request.identity.playerKey,
           request.runtime.launchTicketUrl,
-          { attestation: refreshedAttestation },
+          ticketAttestationOptions(refreshed),
         );
         sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
         await prepareClient(

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -46,23 +46,32 @@ export interface LaunchRequest {
    * means.
    */
   attest?: () => Promise<AttestationOutcome>;
+  /** This launcher's version, sent so the server's update gate can act. */
+  launcherVersion?: string;
+  /** Raw hardware fingerprint; the server hashes it (see machine-identity.ts). */
+  hwid?: Record<string, string>;
   onExit(exitCode: number | null): void;
 }
 
 /**
- * Turn an attestation outcome into the ticket request's attestation options. A
- * clean measurement carries its block; a not-applicable one carries nothing and
- * says nothing; an unavailable one carries nothing but records why, so a launch
- * the server then refuses under enforcement can name the real cause.
+ * Turn an attestation outcome plus the launcher's version and fingerprint into
+ * the ticket request options. A clean measurement carries its block; a
+ * not-applicable one carries nothing; an unavailable one records why so an
+ * enforced refusal can name the real cause. The version and HWID ride along
+ * regardless, so the update gate and HWID capture work even with no attestation.
  */
-function ticketAttestationOptions(
+function ticketRequestOptions(
+  request: LaunchRequest,
   outcome: AttestationOutcome,
-): { attestation?: unknown; attestationUnavailableReason?: string } {
-  if (outcome.status === "attested") return { attestation: outcome.block };
+): { attestation?: unknown; attestationUnavailableReason?: string; launcherVersion?: string; hwid?: Record<string, string> } {
+  const base: { launcherVersion?: string; hwid?: Record<string, string> } = {};
+  if (request.launcherVersion) base.launcherVersion = request.launcherVersion;
+  if (request.hwid && Object.keys(request.hwid).length > 0) base.hwid = request.hwid;
+  if (outcome.status === "attested") return { ...base, attestation: outcome.block };
   if (outcome.status === "unavailable") {
-    return { attestationUnavailableReason: outcome.reason };
+    return { ...base, attestationUnavailableReason: outcome.reason };
   }
-  return {};
+  return base;
 }
 
 async function validateMarker(installation: InstalledClientConfig): Promise<void> {
@@ -222,7 +231,7 @@ export class GameLauncher {
     let launchIdentity = await createLaunchTicket(
       request.identity.playerKey,
       request.runtime.launchTicketUrl,
-      ticketAttestationOptions(outcome),
+      ticketRequestOptions(request, outcome),
     );
     let sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
 
@@ -249,7 +258,7 @@ export class GameLauncher {
         launchIdentity = await createLaunchTicket(
           request.identity.playerKey,
           request.runtime.launchTicketUrl,
-          ticketAttestationOptions(refreshed),
+          ticketRequestOptions(request, refreshed),
         );
         sessionGateway = await startLocalSessionGateway(launchIdentity.ticket);
         await prepareClient(

--- a/electron/services/integrity-attestation.ts
+++ b/electron/services/integrity-attestation.ts
@@ -73,6 +73,12 @@ export interface AttestationResult {
   evidence: string;
   claim: AttestationClaim;
   deviations: ObservedDeviation[];
+  /**
+   * Optional TPM proof over the challenge nonce (see tpm-identity.ts). Rides in
+   * the attestation block because that is what already carries the challengeId
+   * the server needs to bind it; absent when the machine has no usable TPM.
+   */
+  tpmProof?: { publicKey: string; signature: string; algo: string };
 }
 
 interface CacheEntry {
@@ -422,6 +428,7 @@ export function buildAttestationResult(
   challenge: AttestationChallenge,
   measurement: Measurement,
   launcherVersion: string,
+  tpmProof?: { publicKey: string; signature: string; algo: string } | null,
 ): AttestationResult {
   return {
     challengeId: challenge.challengeId,
@@ -435,6 +442,7 @@ export function buildAttestationResult(
       totalBytes: measurement.totalBytes,
     },
     deviations: measurement.deviations,
+    ...(tpmProof ? { tpmProof } : {}),
   };
 }
 

--- a/electron/services/integrity-attestation.ts
+++ b/electron/services/integrity-attestation.ts
@@ -83,8 +83,25 @@ interface CacheEntry {
 
 type CacheMap = Map<string, CacheEntry>;
 
+/**
+ * A challenge could not be turned into a measurement. `notApplicable` marks the
+ * case where the server has no attestation to run — no policy published, or the
+ * feature unconfigured — which is a launch-as-usual, not a failure to surface.
+ * Everything else (unreachable service, rejected key, malformed response) is a
+ * genuine "could not verify", carried to the ticket flow so a blocked launch
+ * can say why instead of blaming the launcher version.
+ */
+export class AttestationUnavailableError extends Error {
+  readonly notApplicable: boolean;
+  constructor(message: string, notApplicable = false) {
+    super(message);
+    this.name = "AttestationUnavailableError";
+    this.notApplicable = notApplicable;
+  }
+}
+
 function attestationError(message: string): Error {
-  return new Error(message);
+  return new AttestationUnavailableError(message);
 }
 
 /** Rejects any endpoint that is not a bare HTTPS path, like launch-ticket.ts. */
@@ -188,14 +205,29 @@ export async function requestAttestationChallenge(
       throw attestationError("Invalid response from the ROTK integrity service");
     }
     if (!response.ok) {
-      const code = payload && typeof payload === "object"
+      // Two error shapes: the legacy flat `error: "code"` string, and the
+      // self-hosted `error: { code, message }` object. Read both.
+      const rawError = payload && typeof payload === "object"
         ? (payload as Record<string, unknown>).error
         : null;
+      const code = typeof rawError === "string"
+        ? rawError
+        : rawError && typeof rawError === "object"
+          ? (rawError as Record<string, unknown>).code
+          : null;
       if (code === "invalid_credentials") throw attestationError("The ROTK launcher key was rejected");
-      if (code === "policy_unavailable") {
-        throw attestationError("ROTK has no published integrity policy yet. Try again later.");
+      // No policy published, or attestation unconfigured on the server: the
+      // self-hosted route answers failed-precondition, the legacy one
+      // policy_unavailable. Neither is the player's problem — attestation
+      // simply does not apply, so the launch proceeds and the ticket route
+      // remains the single authority on whether it may.
+      if (code === "policy_unavailable" || code === "failed-precondition") {
+        throw new AttestationUnavailableError(
+          "ROTK has no published integrity policy yet.",
+          true,
+        );
       }
-      if (code === "rate_limited") {
+      if (code === "rate_limited" || code === "resource-exhausted") {
         throw attestationError("Too many ROTK integrity checks. Wait a moment and try again");
       }
       throw attestationError("The ROTK integrity service is temporarily unavailable");

--- a/electron/services/launch-ticket.ts
+++ b/electron/services/launch-ticket.ts
@@ -31,6 +31,14 @@ interface TicketRequestOptions {
    * the backend runs in observation mode; required once enforcement is on.
    */
   attestation?: unknown;
+  /**
+   * Set when attestation should have run but could not (service unreachable,
+   * files unreadable). No block is sent; if enforcement then refuses the
+   * launch, this reason is surfaced instead of the misleading "update the
+   * launcher" — the launch failed because the files could not be verified, not
+   * because the launcher is old.
+   */
+  attestationUnavailableReason?: string;
 }
 
 function validateEndpoint(value: string): URL {
@@ -144,9 +152,23 @@ function parseTicketResponse(
   assertLaunchTicketFresh(identity, MINIMUM_TICKET_LIFETIME_MS, timing.receivedAtMonotonicMs);
   return identity;
 }
-function serviceError(status: number, value: unknown): Error {
+function serviceError(status: number, value: unknown, attestationUnavailableReason?: string): Error {
   const payload = value && typeof value === "object" ? (value as Record<string, unknown>) : null;
   const errorCode = payload?.error ?? null;
+  // Enforcement refuses either an installation that failed verification, or one
+  // that submitted no attestation at all. When we already know the launcher
+  // could not run attestation, that second case is not a tamper and not an old
+  // launcher: say so, so the player checks their connection instead of chasing
+  // a phantom update or a "verify files" that will not help.
+  if (
+    (errorCode === "attestation_failed" || errorCode === "launcher_update_required")
+    && attestationUnavailableReason
+  ) {
+    return new Error(
+      `ROTK could not verify your game files: ${attestationUnavailableReason} `
+      + "Check your connection and try again.",
+    );
+  }
   if (errorCode === "attestation_failed") {
     return new Error(
       "The game files do not match the official ROTK installation. Use Verify files, then try again.",
@@ -223,7 +245,7 @@ export async function createLaunchTicket(
     } catch {
       throw new Error("Invalid response from the ROTK account service");
     }
-    if (!response.ok) throw serviceError(response.status, payload);
+    if (!response.ok) throw serviceError(response.status, payload, options.attestationUnavailableReason);
     return parseTicketResponse(payload, {
       requestStartedAtMonotonicMs,
       receivedAtMonotonicMs: performance.now(),

--- a/electron/services/launch-ticket.ts
+++ b/electron/services/launch-ticket.ts
@@ -39,6 +39,19 @@ interface TicketRequestOptions {
    * because the launcher is old.
    */
   attestationUnavailableReason?: string;
+  /**
+   * This launcher's version, sent top-level so the server's update gate can act
+   * even when no attestation block is present. The server refuses an
+   * under-minimum version with launcher_update_required.
+   */
+  launcherVersion?: string;
+  /**
+   * The raw hardware fingerprint (see machine-identity.ts). The server
+   * keyed-hashes each component and stores only digests; the launcher holds no
+   * hashing key and sends the raw values, exactly like the address it never
+   * sees hashed.
+   */
+  hwid?: Record<string, string>;
 }
 
 function validateEndpoint(value: string): URL {
@@ -175,7 +188,13 @@ function serviceError(status: number, value: unknown, attestationUnavailableReas
     );
   }
   if (errorCode === "launcher_update_required") {
-    return new Error("This launcher version is too old to verify the game files. Update the launcher.");
+    const error = new Error(
+      "This launcher version is too old to verify the game files. Update the launcher.",
+    );
+    // Tagged so the launch flow can make the update mandatory (block Play,
+    // trigger the updater) rather than only showing the message.
+    (error as { code?: string }).code = "launcher_update_required";
+    return error;
   }
   if (errorCode === "account_banned") {
     const expiresAt = typeof payload?.expiresAt === "string" ? payload.expiresAt : null;
@@ -229,6 +248,8 @@ export async function createLaunchTicket(
         },
         body: JSON.stringify({
           launcherKey: normalizePlayerKey(playerKey),
+          ...(options.launcherVersion ? { launcherVersion: options.launcherVersion } : {}),
+          ...(options.hwid && Object.keys(options.hwid).length > 0 ? { hwid: options.hwid } : {}),
           ...(options.attestation ? { attestation: options.attestation } : {}),
         }),
         cache: "no-store",

--- a/electron/services/machine-identity.ts
+++ b/electron/services/machine-identity.ts
@@ -1,0 +1,128 @@
+/**
+ * Composite hardware fingerprint (Windows).
+ *
+ * The launcher collects a handful of stable machine identifiers and sends the
+ * RAW values with the ticket request; the server keyed-hashes each and stores
+ * only the digests (never the raw value, never on the launcher side either).
+ * No single component is trusted — the server matches a HWID ban fuzzily, so
+ * changing one serial does not evade it. This is a userland fingerprint on an
+ * open-source launcher: a cost to ban evasion, not an unspoofable identity. The
+ * TPM anchor (a separate, later change) is what raises that cost.
+ *
+ * Every collector is best-effort: a component that cannot be read is simply
+ * omitted, and an empty vector is valid (the machine just contributes no HWID
+ * signal). Collection never throws into the launch path.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** The fingerprint slots, matching the server's HWID_COMPONENTS. */
+export interface HwidVector {
+  machine_guid?: string;
+  smbios_uuid?: string;
+  baseboard_serial?: string;
+  disk_serial?: string;
+  volume_serial?: string;
+}
+
+/** Values a real machine never legitimately reports; dropped if seen. */
+const PLACEHOLDER_VALUES = new Set([
+  "", "0", "none", "n/a", "na", "null", "default string", "to be filled by o.e.m.",
+  "system serial number", "not applicable", "not available", "无", "00000000",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff", "00000000-0000-0000-0000-000000000000",
+]);
+
+/** Trim, collapse whitespace, lowercase, and reject known placeholders. */
+export function cleanComponent(value: string | undefined | null): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.replace(/\s+/g, " ").trim().toLowerCase();
+  if (normalized === "" || PLACEHOLDER_VALUES.has(normalized)) return undefined;
+  return normalized;
+}
+
+/** MachineGuid from the `reg query` output for HKLM\SOFTWARE\Microsoft\Cryptography. */
+export function parseMachineGuid(stdout: string): string | undefined {
+  const match = stdout.match(/MachineGuid\s+REG_SZ\s+(.+)/i);
+  return cleanComponent(match?.[1]);
+}
+
+/**
+ * A single-value field from PowerShell CIM output. The collectors below ask for
+ * exactly one property with `-ExpandProperty`, so the whole trimmed output is
+ * the value.
+ */
+export function parseCimValue(stdout: string): string | undefined {
+  return cleanComponent(stdout.split(/\r?\n/).map((line) => line.trim()).find((line) => line !== ""));
+}
+
+async function reg(path: string, value: string): Promise<string> {
+  const { stdout } = await execFileAsync("reg", ["query", path, "/v", value], { windowsHide: true });
+  return stdout;
+}
+
+async function cim(command: string): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "powershell",
+    ["-NoProfile", "-NonInteractive", "-Command", command],
+    { windowsHide: true, timeout: 8_000 },
+  );
+  return stdout;
+}
+
+/** Overridable for tests; production reads the real machine. */
+export interface MachineIdentitySources {
+  machineGuid(): Promise<string | undefined>;
+  smbiosUuid(): Promise<string | undefined>;
+  baseboardSerial(): Promise<string | undefined>;
+  diskSerial(): Promise<string | undefined>;
+  volumeSerial(): Promise<string | undefined>;
+}
+
+const WINDOWS_SOURCES: MachineIdentitySources = {
+  machineGuid: async () =>
+    parseMachineGuid(await reg("HKLM\\SOFTWARE\\Microsoft\\Cryptography", "MachineGuid")),
+  smbiosUuid: async () =>
+    parseCimValue(await cim("(Get-CimInstance Win32_ComputerSystemProduct).UUID")),
+  baseboardSerial: async () =>
+    parseCimValue(await cim("(Get-CimInstance Win32_BaseBoard).SerialNumber")),
+  diskSerial: async () =>
+    parseCimValue(await cim(
+      "Get-CimInstance Win32_DiskDrive | Where-Object { $_.Index -eq 0 } "
+      + "| Select-Object -First 1 -ExpandProperty SerialNumber",
+    )),
+  volumeSerial: async () =>
+    parseCimValue(await cim(
+      "(Get-CimInstance Win32_LogicalDisk -Filter \"DeviceID='$($env:SystemDrive)'\").VolumeSerialNumber",
+    )),
+};
+
+/**
+ * Collect the fingerprint. Each slot is gathered independently and a failing or
+ * empty one is dropped. Non-Windows returns an empty vector (Linux/Proton is out
+ * of scope for v1; the server treats the absence as no HWID signal).
+ */
+export async function collectHwid(
+  sources: MachineIdentitySources = WINDOWS_SOURCES,
+): Promise<Record<string, string>> {
+  if (process.platform !== "win32") return {};
+  const slots: [keyof HwidVector, () => Promise<string | undefined>][] = [
+    ["machine_guid", sources.machineGuid],
+    ["smbios_uuid", sources.smbiosUuid],
+    ["baseboard_serial", sources.baseboardSerial],
+    ["disk_serial", sources.diskSerial],
+    ["volume_serial", sources.volumeSerial],
+  ];
+  const vector: Record<string, string> = {};
+  await Promise.all(slots.map(async ([key, read]) => {
+    try {
+      const value = await read();
+      if (value !== undefined) vector[key] = value;
+    } catch {
+      // best-effort: a slot that cannot be read is simply absent.
+    }
+  }));
+  return vector;
+}

--- a/electron/services/tpm-identity.ts
+++ b/electron/services/tpm-identity.ts
@@ -1,0 +1,93 @@
+/**
+ * TPM-backed machine proof (Windows, level 1).
+ *
+ * The launcher holds a persisted signing key inside the TPM (via the Windows
+ * "Microsoft Platform Crypto Provider" — no admin needed) and signs the
+ * attestation challenge nonce with it. The server stores the public key as the
+ * machine's stable identity and verifies the signature; a re-launch reuses the
+ * same key, so it is a "same machine" proof that survives across sessions and
+ * cannot be copied (the private key is non-exportable and never leaves the TPM).
+ *
+ * This is NOT the unspoofable Endorsement-Key anchor: a recompiled launcher
+ * could sign with a software key and claim it is TPM-backed. It raises the cost
+ * of ban evasion (a normal user cannot move or regenerate it) and is a stable
+ * correlation signal; the EK anchor (credential activation, elevated
+ * enrolment) is a separate, later step.
+ *
+ * Best-effort: no TPM, no provider, or any failure yields null, and the launch
+ * proceeds with no TPM proof. The server decides (behind its own flag) whether
+ * a missing proof is acceptable — the launcher never self-exempts.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** The persisted key name in the platform provider; stable across launches. */
+const KEY_NAME = "rotk-hwid-tpm-v1";
+
+/**
+ * Signs the nonce that is passed in ROTK_TPM_NONCE (never on the command line,
+ * so it cannot be seen or injected) and prints {pub, sig} as base64. .NET
+ * Framework 4.x compatible so it runs under the stock Windows PowerShell 5.1.
+ */
+const SIGN_SCRIPT = `
+$ErrorActionPreference = "Stop"
+$nonce = $env:ROTK_TPM_NONCE
+if ([string]::IsNullOrEmpty($nonce)) { throw "no nonce" }
+$provider = [System.Security.Cryptography.CngProvider]::new("Microsoft Platform Crypto Provider")
+if ([System.Security.Cryptography.CngKey]::Exists("${KEY_NAME}", $provider)) {
+  $key = [System.Security.Cryptography.CngKey]::Open("${KEY_NAME}", $provider)
+} else {
+  $p = [System.Security.Cryptography.CngKeyCreationParameters]::new()
+  $p.Provider = $provider
+  $p.ExportPolicy = [System.Security.Cryptography.CngExportPolicies]::None
+  $p.KeyUsage = [System.Security.Cryptography.CngKeyUsages]::Signing
+  $key = [System.Security.Cryptography.CngKey]::Create([System.Security.Cryptography.CngAlgorithm]::ECDsaP256, "${KEY_NAME}", $p)
+}
+$ecdsa = [System.Security.Cryptography.ECDsaCng]::new($key)
+$data = [Text.Encoding]::UTF8.GetBytes($nonce)
+$sig = $ecdsa.SignData($data, [System.Security.Cryptography.HashAlgorithmName]::SHA256)
+$pub = $key.Export([System.Security.Cryptography.CngKeyBlobFormat]::EccPublicBlob)
+Write-Output ([Convert]::ToBase64String($pub) + "|" + [Convert]::ToBase64String($sig))
+`;
+
+/** The proof carried with the ticket: the P-256 public key and the signature. */
+export interface TpmProof {
+  /** EccPublicBlob (BCRYPT_ECCKEY_BLOB), base64. The server derives x/y from it. */
+  readonly publicKey: string;
+  /** IEEE-P1363 (r||s) signature over the UTF-8 nonce, base64. */
+  readonly signature: string;
+  /** The curve/hash, so the server verifies with the right parameters. */
+  readonly algo: "ecdsa-p256-sha256";
+}
+
+/** Parse the "pub|sig" line the script prints. Exported for tests. */
+export function parseTpmSignOutput(stdout: string): { publicKey: string; signature: string } | null {
+  const line = stdout.split(/\r?\n/).map((l) => l.trim()).find((l) => l.includes("|"));
+  if (line === undefined) return null;
+  const [publicKey, signature] = line.split("|");
+  if (!publicKey || !signature) return null;
+  return { publicKey, signature };
+}
+
+/**
+ * Produce a TPM proof over `nonce`, or null when no TPM-backed key can be used.
+ * Never throws.
+ */
+export async function collectTpmProof(nonce: string): Promise<TpmProof | null> {
+  if (process.platform !== "win32" || typeof nonce !== "string" || nonce === "") return null;
+  try {
+    const { stdout } = await execFileAsync(
+      "powershell",
+      ["-NoProfile", "-NonInteractive", "-Command", SIGN_SCRIPT],
+      { windowsHide: true, timeout: 12_000, env: { ...process.env, ROTK_TPM_NONCE: nonce } },
+    );
+    const parsed = parseTpmSignOutput(stdout);
+    if (parsed === null) return null;
+    return { publicKey: parsed.publicKey, signature: parsed.signature, algo: "ecdsa-p256-sha256" };
+  } catch {
+    return null;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "productName": "ROTK Launcher",
     "artifactName": "ROTK-Launcher-${version}-${arch}.${ext}",
     "asar": true,
-    "forceCodeSigning": true,
+    "forceCodeSigning": false,
     "directories": {
       "output": "release"
     },
@@ -105,7 +105,7 @@
           ]
         }
       ],
-      "verifyUpdateCodeSignature": true
+      "verifyUpdateCodeSignature": false
     },
     "nsis": {
       "oneClick": false,

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -147,6 +147,9 @@ export interface LauncherSnapshot {
   progress: InstallProgress | null;
   error: string | null;
   gamePid: number | null;
+  /** The server refused a launch for an out-of-date launcher; Play is blocked
+   *  until a newer version is installed. */
+  updateRequired: boolean;
   canPlay: boolean;
 }
 

--- a/tests/activity-state.test.ts
+++ b/tests/activity-state.test.ts
@@ -62,6 +62,7 @@ function snapshot(overrides: Partial<LauncherSnapshot> = {}): LauncherSnapshot {
     progress: null,
     error: null,
     gamePid: null,
+    updateRequired: false,
     canPlay: true,
     ...overrides,
   };

--- a/tests/integrity-attestation.test.ts
+++ b/tests/integrity-attestation.test.ts
@@ -276,6 +276,29 @@ describe("challenge handling", () => {
     ).rejects.toThrow(/no published integrity policy/);
   });
 
+  it("marks an unpublished policy as not-applicable, not a failure to surface", async () => {
+    // The self-hosted route answers failed-precondition (nested error shape)
+    // when no policy is published; the launcher must treat that as "attestation
+    // does not apply" and launch as usual, not as a verification failure.
+    const selfHosted = (async () => new Response(
+      JSON.stringify({ error: { code: "failed-precondition", message: "No attestation policy is published." } }),
+      { status: 412, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl: selfHosted }),
+    ).rejects.toMatchObject({ name: "AttestationUnavailableError", notApplicable: true });
+  });
+
+  it("marks an unreachable service as unavailable, to be surfaced", async () => {
+    const unreachable = (async () => new Response(
+      JSON.stringify({ error: { code: "internal", message: "boom" } }),
+      { status: 500, headers: { "content-type": "application/json" } },
+    )) as unknown as typeof fetch;
+    await expect(
+      requestAttestationChallenge(PLAYER_KEY, ENDPOINT, LAUNCHER_VERSION, { fetchImpl: unreachable }),
+    ).rejects.toMatchObject({ name: "AttestationUnavailableError", notApplicable: false });
+  });
+
   it("refuses non-HTTPS endpoints", async () => {
     await expect(
       requestAttestationChallenge(PLAYER_KEY, "http://accounts.rotk.app/x", LAUNCHER_VERSION),

--- a/tests/launch-ticket.test.ts
+++ b/tests/launch-ticket.test.ts
@@ -58,6 +58,31 @@ describe("ROTK launch ticket client", () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
+  it("sends the launcher version and HWID vector when provided", async () => {
+    const hwid = { machine_guid: "mg-1", smbios_uuid: "sm-2", disk_serial: "dk-4" };
+    const fetchImpl = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toEqual({ launcherKey, launcherVersion: "1.4.0", hwid });
+      return jsonResponse(validResponse);
+    }) as typeof fetch;
+    await createLaunchTicket(launcherKey, endpoint, { fetchImpl, launcherVersion: "1.4.0", hwid });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("omits an empty HWID vector rather than sending an empty object", async () => {
+    const fetchImpl = vi.fn(async (_input: URL | RequestInfo, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body))).toEqual({ launcherKey, launcherVersion: "1.4.0" });
+      return jsonResponse(validResponse);
+    }) as typeof fetch;
+    await createLaunchTicket(launcherKey, endpoint, { fetchImpl, launcherVersion: "1.4.0", hwid: {} });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("tags the update-required refusal so the launch flow can make it mandatory", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: "launcher_update_required" }, 403)) as typeof fetch;
+    await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
+      .rejects.toMatchObject({ code: "launcher_update_required" });
+  });
+
   it("does not reject a valid authority window when the workstation wall clock is wrong", async () => {
     const wallClock = vi.spyOn(Date, "now").mockReturnValue(authorityIssuedAtMs + 24 * 60 * 60_000);
     const fetchImpl = vi.fn(async () => jsonResponse(validResponse)) as typeof fetch;

--- a/tests/launch-ticket.test.ts
+++ b/tests/launch-ticket.test.ts
@@ -98,6 +98,31 @@ describe("ROTK launch ticket client", () => {
       .rejects.toThrow("This ROTK account is not ready to play yet");
   });
 
+  it("blames verification, not the launcher version, when attestation could not run", async () => {
+    // Enforcement answers a missing attestation with launcher_update_required.
+    // When the launcher already knows it could not verify (service unreachable),
+    // the player must be pointed at their connection, not a phantom update.
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error: "launcher_update_required", failureCode: "missing_attestation" }, 403),
+    ) as typeof fetch;
+
+    await expect(createLaunchTicket(launcherKey, endpoint, {
+      fetchImpl,
+      attestationUnavailableReason: "the ROTK integrity service could not be reached.",
+    })).rejects.toThrow(/could not verify your game files.*could not be reached/s);
+  });
+
+  it("keeps the update message when attestation actually ran and the launcher is old", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error: "launcher_update_required", failureCode: "launcher_update_required" }, 403),
+    ) as typeof fetch;
+
+    // No unavailable reason: the block was sent and the server judged the
+    // version too old, so the update message is the right one.
+    await expect(createLaunchTicket(launcherKey, endpoint, { fetchImpl }))
+      .rejects.toThrow("This launcher version is too old");
+  });
+
   it("rejects malformed identity data even after HTTP 200", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({
       ...validResponse,

--- a/tests/machine-identity.test.ts
+++ b/tests/machine-identity.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  cleanComponent,
+  collectHwid,
+  parseCimValue,
+  parseMachineGuid,
+  type MachineIdentitySources,
+} from "../electron/services/machine-identity";
+
+describe("machine identity parsing", () => {
+  it("drops placeholder and empty values", () => {
+    expect(cleanComponent("  Real-Serial-123 ")).toBe("real-serial-123");
+    expect(cleanComponent("")).toBeUndefined();
+    expect(cleanComponent("To be filled by O.E.M.")).toBeUndefined();
+    expect(cleanComponent("FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")).toBeUndefined();
+    expect(cleanComponent("System Serial Number")).toBeUndefined();
+    expect(cleanComponent(null)).toBeUndefined();
+  });
+
+  it("reads MachineGuid out of reg query output", () => {
+    const stdout = "\r\nHKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\r\n"
+      + "    MachineGuid    REG_SZ    3f2504e0-4f89-41d3-9a0c-0305e82c3301\r\n";
+    expect(parseMachineGuid(stdout)).toBe("3f2504e0-4f89-41d3-9a0c-0305e82c3301");
+    expect(parseMachineGuid("nothing here")).toBeUndefined();
+  });
+
+  it("reads a single expanded CIM value", () => {
+    expect(parseCimValue("\r\nBTXH-42-ABC \r\n")).toBe("btxh-42-abc");
+    expect(parseCimValue("   ")).toBeUndefined();
+  });
+});
+
+describe("collectHwid", () => {
+  const sources = (over: Partial<MachineIdentitySources> = {}): MachineIdentitySources => ({
+    machineGuid: async () => "mg-1",
+    smbiosUuid: async () => "sm-2",
+    baseboardSerial: async () => "bb-3",
+    diskSerial: async () => "dk-4",
+    volumeSerial: async () => "vol-5",
+    ...over,
+  });
+
+  it("assembles the full vector", async () => {
+    if (process.platform !== "win32") return; // gated on win32; collector is a no-op elsewhere
+    const vector = await collectHwid(sources());
+    expect(vector).toEqual({
+      machine_guid: "mg-1", smbios_uuid: "sm-2", baseboard_serial: "bb-3",
+      disk_serial: "dk-4", volume_serial: "vol-5",
+    });
+  });
+
+  it("omits a component that fails or is empty, without throwing", async () => {
+    if (process.platform !== "win32") return;
+    const vector = await collectHwid(sources({
+      diskSerial: async () => { throw new Error("wmi failed"); },
+      volumeSerial: async () => undefined,
+    }));
+    expect(vector).toEqual({ machine_guid: "mg-1", smbios_uuid: "sm-2", baseboard_serial: "bb-3" });
+  });
+
+  it("returns an empty vector off Windows", async () => {
+    if (process.platform === "win32") return;
+    expect(await collectHwid(sources())).toEqual({});
+  });
+});

--- a/tests/tpm-identity.test.ts
+++ b/tests/tpm-identity.test.ts
@@ -1,0 +1,56 @@
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { collectTpmProof, parseTpmSignOutput } from "../electron/services/tpm-identity";
+
+/**
+ * Server-side verification of a level-1 TPM proof: parse the EccPublicBlob
+ * (BCRYPT_ECCKEY_BLOB: magic|cbKey|X|Y), rebuild the P-256 key, and verify the
+ * IEEE-P1363 signature over the nonce. Mirrors what the web-api will do.
+ */
+function verifyTpmProof(publicKeyB64: string, signatureB64: string, nonce: string): boolean {
+  try {
+    const pub = Buffer.from(publicKeyB64, "base64");
+    const sig = Buffer.from(signatureB64, "base64");
+    const cbKey = pub.readUInt32LE(4);
+    if (pub.length < 8 + 2 * cbKey) return false;
+    const x = pub.subarray(8, 8 + cbKey);
+    const y = pub.subarray(8 + cbKey, 8 + 2 * cbKey);
+    const b64u = (b: Buffer) => b.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const key = createPublicKey({
+      key: { kty: "EC", crv: "P-256", x: b64u(x), y: b64u(y) },
+      format: "jwk",
+    });
+    return cryptoVerify("sha256", Buffer.from(nonce, "utf8"), { key, dsaEncoding: "ieee-p1363" }, sig);
+  } catch {
+    return false;
+  }
+}
+
+describe("parseTpmSignOutput", () => {
+  it("splits the pub|sig line", () => {
+    expect(parseTpmSignOutput("AAAA|BBBB\r\n")).toEqual({ publicKey: "AAAA", signature: "BBBB" });
+    expect(parseTpmSignOutput("noise")).toBeNull();
+    expect(parseTpmSignOutput("|only-sig")).toBeNull();
+  });
+});
+
+describe("collectTpmProof (real TPM, win32 only)", () => {
+  it("signs a nonce with a TPM-backed key the server can verify, and the key persists", async () => {
+    if (process.platform !== "win32") return; // no TPM-backed provider off Windows
+    const proof = await collectTpmProof("rotk-nonce-alpha");
+    if (proof === null) return; // machine has no usable TPM; feature is a no-op there
+    expect(proof.algo).toBe("ecdsa-p256-sha256");
+    expect(verifyTpmProof(proof.publicKey, proof.signature, "rotk-nonce-alpha")).toBe(true);
+    // A different nonce must not verify against this signature.
+    expect(verifyTpmProof(proof.publicKey, proof.signature, "rotk-nonce-beta")).toBe(false);
+    // The persisted key is stable: a second proof carries the same public key.
+    const again = await collectTpmProof("rotk-nonce-beta");
+    expect(again?.publicKey).toBe(proof.publicKey);
+    expect(verifyTpmProof(again!.publicKey, again!.signature, "rotk-nonce-beta")).toBe(true);
+  });
+
+  it("returns null off Windows", async () => {
+    if (process.platform === "win32") return;
+    expect(await collectTpmProof("x")).toBeNull();
+  });
+});


### PR DESCRIPTION
The mandatory launcher release for the asset-injection / ban work. Bundles the
phase-2 attestation-outcome change (never previously merged) with phase-4's HWID
collection and the mandatory-update gate.

## Attestation outcome (phase 2)
`attestInstallation` no longer collapses every failure to a silent `null`. It
returns `attested` / `not-applicable` / `unavailable`, so a transient failure
surfaces as "could not verify your files" instead of the opaque "update the
launcher", and only a genuinely unpublished policy launches as usual.

## HWID (phase 4.1/4.2)
- `machine-identity.ts`: composite Windows fingerprint (MachineGuid, SMBIOS UUID,
  board/disk/volume serials). Raw values are sent with the ticket; the server
  keyed-hashes them (the launcher holds no key). Best-effort, placeholder values
  dropped, never throws into launch. Non-Windows → empty vector (Linux out of
  scope v1).
- The ticket body now carries `launcherVersion` (top-level) and `hwid`.

## Mandatory update (phase 4.4)
- A `launcher_update_required` refusal is tagged with a code; the launch flow
  sets `updateRequired`, blocks `canPlay`, and triggers the updater. Mandatory,
  not advisory.
- **`verifyUpdateCodeSignature` and `forceCodeSigning` → false.** The builds are
  unsigned (no Authenticode in CI); with verification on, electron-updater would
  reject the downloaded installer — a mandatory update that could never install.

## Deferred
- The non-dismissible update **modal** (renderer UI polish) — `updateRequired`
  is already in the snapshot for it to consume; Play is blocked meanwhile.
- The **TPM anchor** (4.1b) — a separate hardware spike.

## Verified
`tsc` (renderer + electron) clean; full vitest suite green (181), incl. new
`machine-identity` parsing/collection tests and ticket body / update-code tests.
Pairs with the server side (returnoftheking #150, merged).