### PR TITLE
feat: add local H1Z1 playtime counter and launcher polish

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,22 @@
+!macro customInstall
+  StrCpy $0 "$INSTDIR\resources\icon.ico"
+  ${ifNot} ${FileExists} "$0"
+    StrCpy $0 "$appExe"
+  ${endIf}
+
+  ${if} ${FileExists} "$newDesktopLink"
+    Delete "$newDesktopLink"
+    CreateShortCut "$newDesktopLink" "$appExe" "" "$0" 0 "" "" "${APP_DESCRIPTION}"
+    ClearErrors
+    WinShell::SetLnkAUMI "$newDesktopLink" "${APP_ID}"
+  ${endIf}
+
+  ${if} ${FileExists} "$newStartMenuLink"
+    Delete "$newStartMenuLink"
+    CreateShortCut "$newStartMenuLink" "$appExe" "" "$0" 0 "" "" "${APP_DESCRIPTION}"
+    ClearErrors
+    WinShell::SetLnkAUMI "$newStartMenuLink" "${APP_ID}"
+  ${endIf}
+
+  System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+!macroend

--- a/electron/constants.ts
+++ b/electron/constants.ts
@@ -1,7 +1,9 @@
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { app } from "electron";
 
 export const APP_NAME = "ROTK Launcher";
+export const APP_USER_MODEL_ID = "app.rotk.launcher";
 export const WEBSITE_ORIGIN = "https://rotk.app";
 export const WEBSITE_UPDATES_PATH = "/updates";
 export const FORBIDDEN_INSTALL_SEGMENTS = new Set([
@@ -20,6 +22,14 @@ export const CRITICAL_CLIENT_FILES = [
 export const ROTK_INSTALL_DIRECTORY_NAME = "ROTK";
 export const RECOMMENDED_INSTALL_PARENT_NAME = "Games";
 export const INSTALL_MARKER_NAME = ".rotk-installation.json";
+
+export function resolveAppIconPath(): string {
+  if (app.isPackaged) {
+    const fromResources = join(process.resourcesPath, "icon.ico");
+    if (existsSync(fromResources)) return fromResources;
+  }
+  return join(app.getAppPath(), "build", "icon.ico");
+}
 
 export function resolveBundledShimPath(): string {
   return app.isPackaged

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,8 +41,10 @@ import {
 } from "../shared/launch-profile.js";
 import {
   APP_NAME,
+  APP_USER_MODEL_ID,
   RECOMMENDED_INSTALL_PARENT_NAME,
   ROTK_INSTALL_DIRECTORY_NAME,
+  resolveAppIconPath,
   resolveBundledShimPath,
   resolveBundledVivoxProxyPath,
   resolveBundledVivoxRuntimePath,
@@ -58,6 +60,7 @@ import { collectHwid } from "./services/machine-identity.js";
 import { collectTpmProof } from "./services/tpm-identity.js";
 import { classifyClientSource, validateInstallDestination } from "./services/path-policy.js";
 import { locateSteamClient } from "./services/steam-locator.js";
+import { locateIsolatedRotkClient } from "./services/rotk-locator.js";
 import {
   runtimeConfigFor,
   runtimeConfigList,
@@ -77,6 +80,8 @@ import { localizeServiceError, MAIN_COPY } from "./i18n.js";
 import { identityFromPlayerKey } from "./services/player-identity.js";
 import { PlayerKeyStore, type PlayerKeySet } from "./services/player-key-store.js";
 import { readInstallationMarker } from "./services/installer.js";
+import { PlaytimeStore } from "./services/playtime-store.js";
+import { PlaytimeTracker } from "./services/playtime-tracker.js";
 import {
   BASE_MANIFEST_URL,
   loadBaseManifest,
@@ -92,6 +97,7 @@ import {
 } from "./services/integrity-attestation.js";
 
 app.setName(APP_NAME);
+app.setAppUserModelId(APP_USER_MODEL_ID);
 if (!app.isPackaged && process.env.ROTK_USER_DATA_DIR) {
   app.setPath("userData", resolve(process.env.ROTK_USER_DATA_DIR));
 } else {
@@ -118,6 +124,9 @@ let updateFeed: UpdateFeedService;
 let assetSync: AssetSyncService;
 let launcherUpdate: LauncherUpdateService;
 const gameLauncher = new GameLauncher();
+const playtimeTracker = new PlaytimeTracker(new PlaytimeStore(app.getPath("userData")), {
+  onChange: () => void broadcastSnapshot(),
+});
 const LAUNCHER_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
 let installAbortController: AbortController | null = null;
 let phase: LauncherPhase = "unconfigured";
@@ -414,6 +423,7 @@ async function snapshot(): Promise<LauncherSnapshot> {
     progress,
     error: lastErrorRaw ? localizeServiceError(lastErrorRaw, currentLocale) : null,
     gamePid,
+    playtime: playtimeTracker.summary(),
     updateRequired,
     canPlay:
       phase === "ready"
@@ -588,7 +598,7 @@ function registerIpc(): void {
       if (installAbortController) return { ok: false, error: copy.installationInProgress };
       if (sourceRoot) return { ok: true, value: { sourceRoot } };
       try {
-        const located = await locateSteamClient();
+        const located = await locateIsolatedRotkClient() ?? await locateSteamClient();
         if (!located) return { ok: true, value: { sourceRoot: null } };
         const selectedClient = await classifyClientSource(located);
         sourceRoot = selectedClient.root;
@@ -801,12 +811,15 @@ function registerIpc(): void {
           onExit: () => {
             gamePid = null;
             phase = "ready";
-            void broadcastSnapshot();
-            if (quitWhenGameExits && !mainWindow) app.quit();
+            void playtimeTracker.endSession().finally(() => {
+              void broadcastSnapshot();
+              if (quitWhenGameExits && !mainWindow) app.quit();
+            });
           },
         });
         gamePid = pid;
         phase = "running";
+        playtimeTracker.startSession();
         await broadcastSnapshot();
         return { ok: true, value: { pid } };
       } catch (error) {
@@ -947,6 +960,7 @@ function createWindow(): BrowserWindow {
     frame: false,
     backgroundColor: "#090909",
     title: "ROTK Launcher",
+    icon: resolveAppIconPath(),
     webPreferences: {
       preload: join(currentDirectory, "preload.cjs"),
       contextIsolation: true,
@@ -1001,6 +1015,7 @@ async function initialize(): Promise<void> {
     join(app.getPath("userData"), "player-key.v1.json"),
   );
   playerKeys = await playerKeyStore.load();
+  await playtimeTracker.initialize();
   updateFeed = new UpdateFeedService(app.getPath("userData"));
   assetSync = new AssetSyncService({
     userDataDirectory: app.getPath("userData"),
@@ -1026,6 +1041,28 @@ async function initialize(): Promise<void> {
     } catch (error) {
       phase = "error";
       lastErrorRaw = rawErrorMessage(error);
+    }
+  } else {
+    const discovered = await locateIsolatedRotkClient();
+    if (discovered) {
+      const marker = await readInstallationMarker(discovered);
+      if (marker) {
+        const installation = {
+          installId: marker.installId,
+          clientBuildId: marker.clientBuildId,
+          root: discovered,
+          sourceRoot: marker.sourceRoot,
+          installedAt: marker.installedAt,
+          criticalHashes: marker.criticalHashes,
+        };
+        try {
+          await validateInstalledClient(installation);
+          await configStore.setInstallation(installation);
+          phase = "ready";
+        } catch {
+          // Discovery is best-effort; the setup panel remains available.
+        }
+      }
     }
   }
   launcherUpdate = new LauncherUpdateService({
@@ -1072,6 +1109,11 @@ app.on("window-all-closed", () => {
     return;
   }
   app.quit();
+});
+
+app.on("before-quit", () => {
+  playtimeTracker.dispose();
+  void playtimeTracker.endSession();
 });
 
 process.on("uncaughtException", (error) => {

--- a/electron/services/playtime-store.ts
+++ b/electron/services/playtime-store.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const PLAYTIME_FILE_NAME = "playtime.v1.json";
+export const PLAYTIME_SCHEMA_VERSION = 1 as const;
+
+export interface PlaytimeRecord {
+  schemaVersion: typeof PLAYTIME_SCHEMA_VERSION;
+  totalSeconds: number;
+}
+
+export function emptyPlaytime(): PlaytimeRecord {
+  return { schemaVersion: PLAYTIME_SCHEMA_VERSION, totalSeconds: 0 };
+}
+
+export function isValidPlaytimeSeconds(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && Number.isFinite(value)
+    && value >= 0
+    && value <= Number.MAX_SAFE_INTEGER;
+}
+
+export function parsePlaytimeRecord(value: unknown): PlaytimeRecord | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { schemaVersion?: unknown; totalSeconds?: unknown };
+  if (candidate.schemaVersion !== PLAYTIME_SCHEMA_VERSION) return null;
+  if (!isValidPlaytimeSeconds(candidate.totalSeconds)) return null;
+  return { schemaVersion: PLAYTIME_SCHEMA_VERSION, totalSeconds: candidate.totalSeconds };
+}
+
+export function clampPlaytimeSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value));
+}
+
+/**
+ * Local, versioned play-time file. A corrupt or missing file resets to zero
+ * without throwing: this counter must never block the launcher or a launch.
+ */
+export class PlaytimeStore {
+  private readonly path: string;
+  private record: PlaytimeRecord | null = null;
+
+  constructor(userDataDirectory: string) {
+    this.path = join(userDataDirectory, PLAYTIME_FILE_NAME);
+  }
+
+  filePath(): string {
+    return this.path;
+  }
+
+  async load(): Promise<PlaytimeRecord> {
+    if (this.record) return this.record;
+
+    try {
+      const parsed: unknown = JSON.parse(await readFile(this.path, "utf8"));
+      const valid = parsePlaytimeRecord(parsed);
+      if (valid) {
+        this.record = valid;
+        return valid;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT" && !(error instanceof SyntaxError)) {
+        console.warn("Playtime file could not be read", error);
+      }
+    }
+
+    this.record = emptyPlaytime();
+    try {
+      await this.writeAtomic(this.record);
+    } catch (error) {
+      console.warn("Playtime file could not be initialized", error);
+    }
+    return this.record;
+  }
+
+  async save(totalSeconds: number): Promise<void> {
+    const next: PlaytimeRecord = {
+      schemaVersion: PLAYTIME_SCHEMA_VERSION,
+      totalSeconds: clampPlaytimeSeconds(totalSeconds),
+    };
+    await this.writeAtomic(next);
+    this.record = next;
+  }
+
+  private async writeAtomic(next: PlaytimeRecord): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporaryPath, `${JSON.stringify(next, null, 2)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      await rename(temporaryPath, this.path);
+    } catch (error) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+}

--- a/electron/services/playtime-tracker.ts
+++ b/electron/services/playtime-tracker.ts
@@ -1,0 +1,138 @@
+import type { PlaytimeSummary } from "../../shared/contracts.js";
+import { clampPlaytimeSeconds, PlaytimeStore } from "./playtime-store.js";
+
+export const DEFAULT_PLAYTIME_PERSIST_INTERVAL_MS = 30_000;
+
+export interface PlaytimeClock {
+  nowNs(): bigint;
+}
+
+export const hrtimeClock: PlaytimeClock = {
+  nowNs: () => process.hrtime.bigint(),
+};
+
+export interface PlaytimeTrackerOptions {
+  clock?: PlaytimeClock;
+  persistIntervalMs?: number;
+  onChange?: () => void;
+}
+
+interface ActiveSession {
+  startedNs: bigint;
+  accountedSeconds: number;
+}
+
+export function elapsedSeconds(startNs: bigint, nowNs: bigint): number {
+  if (nowNs <= startNs) return 0;
+  const asNumber = Number((nowNs - startNs) / 1_000_000_000n);
+  return clampPlaytimeSeconds(asNumber);
+}
+
+/**
+ * Counts only H1Z1 sessions spawned by the launcher. Uses a monotonic clock so
+ * a Windows time change cannot inflate or rewind the total.
+ */
+export class PlaytimeTracker {
+  private committedSeconds = 0;
+  private session: ActiveSession | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private persistQueue: Promise<void> = Promise.resolve();
+  private readonly clock: PlaytimeClock;
+  private readonly persistIntervalMs: number;
+  private readonly onChange?: () => void;
+
+  constructor(
+    private readonly store: PlaytimeStore,
+    options: PlaytimeTrackerOptions = {},
+  ) {
+    this.clock = options.clock ?? hrtimeClock;
+    this.persistIntervalMs = options.persistIntervalMs ?? DEFAULT_PLAYTIME_PERSIST_INTERVAL_MS;
+    this.onChange = options.onChange;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      this.committedSeconds = (await this.store.load()).totalSeconds;
+    } catch (error) {
+      console.warn("Playtime could not be loaded", error);
+      this.committedSeconds = 0;
+    }
+  }
+
+  summary(): PlaytimeSummary {
+    return {
+      totalSeconds: this.displayedSeconds(),
+      sessionActive: this.session !== null,
+    };
+  }
+
+  displayedSeconds(): number {
+    return this.committedSeconds + this.unaccountedSeconds();
+  }
+
+  isSessionActive(): boolean {
+    return this.session !== null;
+  }
+
+  /** Begin counting after H1Z1.exe has actually been spawned. */
+  startSession(): void {
+    if (this.session) return;
+    this.session = { startedNs: this.clock.nowNs(), accountedSeconds: 0 };
+    this.timer = setInterval(() => {
+      void this.checkpoint();
+    }, this.persistIntervalMs);
+    this.timer.unref?.();
+  }
+
+  async endSession(): Promise<void> {
+    if (!this.session) return;
+    this.clearTimer();
+    this.absorbSession();
+    this.session = null;
+    await this.persistCommitted();
+    this.onChange?.();
+  }
+
+  async checkpoint(): Promise<void> {
+    if (!this.session) return;
+    this.absorbSession();
+    await this.persistCommitted();
+    this.onChange?.();
+  }
+
+  dispose(): void {
+    this.clearTimer();
+  }
+
+  private unaccountedSeconds(): number {
+    if (!this.session) return 0;
+    const elapsed = elapsedSeconds(this.session.startedNs, this.clock.nowNs());
+    const extra = elapsed - this.session.accountedSeconds;
+    return extra > 0 ? extra : 0;
+  }
+
+  private absorbSession(): void {
+    if (!this.session) return;
+    const extra = this.unaccountedSeconds();
+    if (extra <= 0) return;
+    this.committedSeconds += extra;
+    this.session.accountedSeconds += extra;
+  }
+
+  private async persistCommitted(): Promise<void> {
+    this.persistQueue = this.persistQueue.then(async () => {
+      try {
+        await this.store.save(this.committedSeconds);
+      } catch (error) {
+        console.warn("Playtime could not be saved", error);
+      }
+    });
+    await this.persistQueue;
+  }
+
+  private clearTimer(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/electron/services/rotk-locator.ts
+++ b/electron/services/rotk-locator.ts
@@ -1,0 +1,103 @@
+import { constants as fsConstants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { join, normalize } from "node:path";
+import { RECOMMENDED_INSTALL_PARENT_NAME, ROTK_INSTALL_DIRECTORY_NAME } from "../constants.js";
+import { classifyClientSource } from "./path-policy.js";
+import { readInstallationMarker } from "./installer.js";
+
+export interface RotkLocatorDependencies {
+  directoryExists(path: string): Promise<boolean>;
+  classify(path: string): Promise<{ root: string; kind: "direct" | "copy-required" }>;
+  hasMarker(path: string): Promise<boolean>;
+  systemDrive: string;
+  availableDrives: readonly string[];
+}
+
+const DEFAULT_DEPENDENCIES: RotkLocatorDependencies = {
+  directoryExists: async (path) => {
+    try {
+      await access(path, fsConstants.R_OK);
+      return (await stat(path)).isDirectory();
+    } catch {
+      return false;
+    }
+  },
+  classify: classifyClientSource,
+  hasMarker: async (path) => (await readInstallationMarker(path)) !== null,
+  systemDrive: process.env.SystemDrive ?? "C:",
+  availableDrives: windowsDriveLetters(),
+};
+
+function windowsDriveLetters(): string[] {
+  const letters: string[] = [];
+  for (let code = 65; code <= 90; code += 1) {
+    letters.push(`${String.fromCharCode(code)}:`);
+  }
+  return letters;
+}
+
+function driveRoot(drive: string): string {
+  const trimmed = drive.replace(/[\\/]+$/, "");
+  return trimmed.endsWith(":") ? `${trimmed}\\` : `${trimmed}\\`;
+}
+
+/**
+ * Likely standalone ROTK client folders: <drive>\Games\ROTK then <drive>\ROTK.
+ * The system drive is listed first so the documented default stays preferred.
+ */
+export function listIsolatedRotkCandidates(
+  systemDrive: string,
+  availableDrives: readonly string[],
+): string[] {
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  const add = (root: string): void => {
+    const next = normalize(root);
+    const key = next.toLocaleLowerCase("en-US");
+    if (seen.has(key)) return;
+    seen.add(key);
+    candidates.push(next);
+  };
+
+  const folders = [
+    [RECOMMENDED_INSTALL_PARENT_NAME, ROTK_INSTALL_DIRECTORY_NAME],
+    [ROTK_INSTALL_DIRECTORY_NAME],
+  ] as const;
+
+  const drives = [
+    systemDrive,
+    ...availableDrives.filter((drive) => drive.replace(/\\/g, "").toLocaleLowerCase("en-US")
+      !== systemDrive.replace(/\\/g, "").toLocaleLowerCase("en-US")),
+  ];
+
+  for (const drive of drives) {
+    const root = driveRoot(drive);
+    for (const parts of folders) add(join(root, ...parts));
+  }
+  return candidates;
+}
+
+/**
+ * Find an already-isolated ROTK client (outside Steam). A folder with a
+ * `.rotk-installation.json` marker wins over a bare H1Z1 tree.
+ */
+export async function locateIsolatedRotkClient(
+  overrides: Partial<RotkLocatorDependencies> = {},
+): Promise<string | null> {
+  const deps: RotkLocatorDependencies = { ...DEFAULT_DEPENDENCIES, ...overrides };
+  const candidates = listIsolatedRotkCandidates(deps.systemDrive, deps.availableDrives);
+  let firstValid: string | null = null;
+
+  for (const candidate of candidates) {
+    if (!await deps.directoryExists(candidate)) continue;
+    try {
+      const classified = await deps.classify(candidate);
+      if (classified.kind !== "direct") continue;
+      if (await deps.hasMarker(classified.root)) return classified.root;
+      firstValid ??= classified.root;
+    } catch {
+      continue;
+    }
+  }
+  return firstValid;
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
           "**/*.dll",
           "**/*.sha256"
         ]
+      },
+      {
+        "from": "build/icon.ico",
+        "to": "icon.ico"
       }
     ],
     "win": {
@@ -112,7 +116,11 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "ROTK Launcher"
+      "shortcutName": "ROTK Launcher",
+      "installerIcon": "build/icon.ico",
+      "uninstallerIcon": "build/icon.ico",
+      "installerHeaderIcon": "build/icon.ico",
+      "include": "build/installer.nsh"
     }
   }
 }

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -133,6 +133,14 @@ export interface IntegrityCheckSummary {
   totalBytes: number;
 }
 
+/** Local H1Z1 play time. Never sent to a server. */
+export interface PlaytimeSummary {
+  /** Committed seconds plus the live launcher-started session. */
+  totalSeconds: number;
+  /** True only while H1Z1.exe started by this launcher is being counted. */
+  sessionActive: boolean;
+}
+
 export interface LauncherSnapshot {
   appVersion: string;
   phase: LauncherPhase;
@@ -147,6 +155,7 @@ export interface LauncherSnapshot {
   progress: InstallProgress | null;
   error: string | null;
   gamePid: number | null;
+  playtime: PlaytimeSummary;
   /** The server refused a launch for an out-of-date launcher; Play is blocked
    *  until a newer version is installed. */
   updateRequired: boolean;

--- a/src/components/LauncherFooter.tsx
+++ b/src/components/LauncherFooter.tsx
@@ -1,7 +1,9 @@
-import { CircleAlert, KeyRound, Play, RotateCcw, Settings2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { CircleAlert, Clock, KeyRound, Play, RotateCcw, Settings2 } from "lucide-react";
 import type { LauncherSnapshot } from "../../shared/contracts";
 import type { PlayerRole, ServerId } from "../../shared/launch-profile";
 import { useI18n, type Copy } from "../i18n";
+import { formatPlaytimeHours } from "../playtime-format";
 import { ServerSelect } from "./ServerSelect";
 
 interface LauncherFooterProps {
@@ -62,6 +64,42 @@ function statusCopy(snapshot: LauncherSnapshot, copy: Copy): { label: string; de
   return { label: copy.footer.setupRequired, detail: copy.footer.createIndependentInstall };
 }
 
+function PlaytimeBadge({ snapshot, copy }: { snapshot: LauncherSnapshot; copy: Copy }) {
+  const baseline = snapshot.playtime.totalSeconds;
+  const live = snapshot.playtime.sessionActive;
+  const [liveExtra, setLiveExtra] = useState(0);
+
+  useEffect(() => {
+    if (!live) {
+      setLiveExtra(0);
+      return;
+    }
+    const started = performance.now();
+    const tick = (): void => {
+      setLiveExtra(Math.floor((performance.now() - started) / 1000));
+    };
+    const id = window.setInterval(tick, 15_000);
+    return () => window.clearInterval(id);
+  }, [live, baseline]);
+
+  const formatted = formatPlaytimeHours(baseline + liveExtra);
+  const hint = `${copy.footer.playTime}. ${copy.footer.playTimeHint}`;
+
+  return (
+    <div
+      className={`playtime-badge ${live ? "is-live" : ""}`}
+      title={hint}
+      aria-label={`${copy.footer.playTime}: ${formatted}`}
+    >
+      <Clock size={16} aria-hidden="true" />
+      <div>
+        <span>{copy.footer.playTime}</span>
+        <strong>{formatted}</strong>
+      </div>
+    </div>
+  );
+}
+
 export function LauncherFooter({
   snapshot,
   busy,
@@ -90,10 +128,11 @@ export function LauncherFooter({
     <footer className="launcher-footer">
       <div className="launcher-footer__status">
         <span className={`status-pulse ${snapshot.canPlay ? "is-ready" : ""}`} />
-        <div>
+        <div className="launcher-footer__status-copy">
           <strong>{status.label}</strong>
           <small title={status.detail}>{status.detail}</small>
         </div>
+        <PlaytimeBadge snapshot={snapshot} copy={copy} />
       </div>
 
       <ServerSelect

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -69,6 +69,8 @@ export interface Copy {
     playersInGame: string;
     playersUnavailable: string;
     playersUnknown: string;
+    playTime: string;
+    playTimeHint: string;
   };
   identity: {
     panelLabel: string;
@@ -231,6 +233,8 @@ const COPY: Record<AppLocale, Copy> = {
       playersInGame: "IN GAME",
       playersUnavailable: "—",
       playersUnknown: "Player count unavailable",
+      playTime: "Play time",
+      playTimeHint: "Time spent in H1Z1 after a launch from this launcher. Stored only on this computer.",
     },
     identity: {
       panelLabel: "ROTK account authentication",
@@ -423,6 +427,8 @@ const COPY: Record<AppLocale, Copy> = {
       playersInGame: "EN JEU",
       playersUnavailable: "—",
       playersUnknown: "Nombre de joueurs indisponible",
+      playTime: "Temps de jeu",
+      playTimeHint: "Temps passé dans H1Z1 après un lancement depuis ce launcher. Conservé uniquement sur cet ordinateur.",
     },
     identity: {
       panelLabel: "Authentification du compte ROTK",

--- a/src/playtime-format.ts
+++ b/src/playtime-format.ts
@@ -1,0 +1,12 @@
+/** Whole hours and minutes, stable enough for the footer. Seconds stay out of view. */
+export function formatPlaytimeHours(totalSeconds: number): string {
+  const seconds = sanitizeDisplayedPlaytime(totalSeconds);
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  return `${hours} h ${minutes.toString().padStart(2, "0")}`;
+}
+
+export function sanitizeDisplayedPlaytime(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Number.MAX_SAFE_INTEGER, Math.floor(value));
+}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -705,6 +705,13 @@ button:focus-visible {
   border-right: 1px solid var(--line);
 }
 
+.launcher-footer__status {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 28px;
+}
+
 .server-select__trigger {
   width: 100%;
   height: 100%;
@@ -856,12 +863,49 @@ button:focus-visible {
   box-shadow: 0 0 0 5px rgba(134, 169, 110, 0.1);
 }
 
-.launcher-footer__status > div,
+.launcher-footer__status-copy,
 .server-select__trigger > div {
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.playtime-badge {
+  margin-left: auto;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  color: var(--paper);
+}
+
+.playtime-badge > div {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.playtime-badge > svg {
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+.playtime-badge.is-live > svg {
+  color: #86a96e;
+}
+
+.playtime-badge span {
+  color: var(--muted);
+  font-family: "Barlow Condensed", sans-serif;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.playtime-badge strong {
+  font-variant-numeric: tabular-nums;
 }
 
 .launcher-footer__status strong,
@@ -870,11 +914,18 @@ button:focus-visible {
   font-weight: 600;
   font-size: 16px;
   letter-spacing: 0.08em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.launcher-footer__status small {
+.launcher-footer__status-copy {
+  overflow: hidden;
+}
+
+.launcher-footer__status-copy small {
   display: block;
-  max-width: 470px;
+  max-width: 100%;
   overflow: hidden;
   color: var(--muted);
   font-family: "Barlow Condensed", sans-serif;
@@ -1947,12 +1998,29 @@ button:focus-visible {
   }
 
   .launcher-footer {
-    grid-template-columns: minmax(300px, 1fr) 245px 104px 220px;
+    grid-template-columns: minmax(200px, 1fr) minmax(300px, 1.25fr) 96px 200px;
   }
 
   .launcher-footer__status,
   .launcher-footer__server {
-    padding-inline: 20px;
+    padding-inline: 16px;
+  }
+
+  .server-select__trigger {
+    gap: 10px;
+    padding: 0 16px;
+  }
+
+  .server-select__trigger > .server-population small {
+    display: none;
+  }
+
+  .server-select__trigger i {
+    padding: 4px 6px;
+  }
+
+  .playtime-badge {
+    gap: 8px;
   }
 
   .news-carousel__content {

--- a/tests/activity-state.test.ts
+++ b/tests/activity-state.test.ts
@@ -62,6 +62,10 @@ function snapshot(overrides: Partial<LauncherSnapshot> = {}): LauncherSnapshot {
     progress: null,
     error: null,
     gamePid: null,
+    playtime: {
+      totalSeconds: 0,
+      sessionActive: false,
+    },
     updateRequired: false,
     canPlay: true,
     ...overrides,
@@ -73,6 +77,14 @@ describe("homepage activity selector", () => {
     "stays hidden while %s is idle",
     (phase) => expect(selectGlobalActivities(snapshot({ phase }))).toEqual([]),
   );
+
+  it("keeps a local playtime summary on idle snapshots without creating an activity", () => {
+    const current = snapshot({
+      playtime: { totalSeconds: 7260, sessionActive: true },
+    });
+    expect(current.playtime).toEqual({ totalSeconds: 7260, sessionActive: true });
+    expect(selectGlobalActivities(current)).toEqual([]);
+  });
 
   it("shows installation immediately, before the first progress event", () => {
     expect(selectGlobalActivities(snapshot({ phase: "installing" }))).toMatchObject([

--- a/tests/playtime-format.test.ts
+++ b/tests/playtime-format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatPlaytimeHours, sanitizeDisplayedPlaytime } from "../src/playtime-format.js";
+
+describe("playtime formatting", () => {
+  it("renders the first-use value as 0 h 00", () => {
+    expect(formatPlaytimeHours(0)).toBe("0 h 00");
+    expect(formatPlaytimeHours(59)).toBe("0 h 00");
+  });
+
+  it("renders two hours and seven minutes", () => {
+    expect(formatPlaytimeHours(2 * 3600 + 7 * 60)).toBe("2 h 07");
+    expect(formatPlaytimeHours(2 * 3600 + 7 * 60 + 59)).toBe("2 h 07");
+  });
+
+  it("renders durations above 100 hours without wrapping", () => {
+    expect(formatPlaytimeHours(128 * 3600 + 42 * 60)).toBe("128 h 42");
+  });
+
+  it("never formats a negative or non-finite value", () => {
+    expect(formatPlaytimeHours(-12)).toBe("0 h 00");
+    expect(formatPlaytimeHours(Number.NaN)).toBe("0 h 00");
+    expect(formatPlaytimeHours(Number.POSITIVE_INFINITY)).toBe("0 h 00");
+    expect(sanitizeDisplayedPlaytime(-4)).toBe(0);
+  });
+});

--- a/tests/playtime-store.test.ts
+++ b/tests/playtime-store.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  emptyPlaytime,
+  parsePlaytimeRecord,
+  PlaytimeStore,
+} from "../electron/services/playtime-store.js";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "rotk-playtime-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("PlaytimeStore", () => {
+  it("starts at zero on first use and writes the versioned file", async () => {
+    const directory = await temporaryDirectory();
+    const loaded = await new PlaytimeStore(directory).load();
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+
+    expect(loaded).toEqual({ schemaVersion: 1, totalSeconds: 0 });
+    expect(persisted).toEqual(emptyPlaytime());
+  });
+
+  it("reloads an existing duration", async () => {
+    const directory = await temporaryDirectory();
+    await new PlaytimeStore(directory).save(7260);
+
+    const reloaded = await new PlaytimeStore(directory).load();
+    expect(reloaded).toEqual({ schemaVersion: 1, totalSeconds: 7260 });
+  });
+
+  it("recovers to zero when the file is missing or corrupt", async () => {
+    const missingDirectory = await temporaryDirectory();
+    expect(await new PlaytimeStore(missingDirectory).load()).toEqual(emptyPlaytime());
+
+    const corruptDirectory = await temporaryDirectory();
+    await writeFile(join(corruptDirectory, "playtime.v1.json"), "{broken", "utf8");
+    const recovered = await new PlaytimeStore(corruptDirectory).load();
+    const persisted = JSON.parse(await readFile(join(corruptDirectory, "playtime.v1.json"), "utf8"));
+
+    expect(recovered).toEqual(emptyPlaytime());
+    expect(persisted).toEqual(emptyPlaytime());
+  });
+
+  it("rejects negative, non-finite and otherwise invalid records", () => {
+    expect(parsePlaytimeRecord({ schemaVersion: 1, totalSeconds: -1 })).toBeNull();
+    expect(parsePlaytimeRecord({ schemaVersion: 1, totalSeconds: Number.POSITIVE_INFINITY })).toBeNull();
+    expect(parsePlaytimeRecord({ schemaVersion: 1, totalSeconds: Number.NaN })).toBeNull();
+    expect(parsePlaytimeRecord({ schemaVersion: 1, totalSeconds: 1.5 })).toBeNull();
+    expect(parsePlaytimeRecord({ schemaVersion: 1, totalSeconds: "12" })).toBeNull();
+    expect(parsePlaytimeRecord({ schemaVersion: 2, totalSeconds: 12 })).toBeNull();
+    expect(parsePlaytimeRecord({ totalSeconds: 12 })).toBeNull();
+  });
+
+  it("recovers a persisted negative or invalid file instead of trusting it", async () => {
+    const directory = await temporaryDirectory();
+    await writeFile(join(directory, "playtime.v1.json"), JSON.stringify({
+      schemaVersion: 1,
+      totalSeconds: -40,
+    }), "utf8");
+
+    const recovered = await new PlaytimeStore(directory).load();
+    expect(recovered.totalSeconds).toBe(0);
+    expect(recovered.totalSeconds).toBeGreaterThanOrEqual(0);
+  });
+
+  it("writes atomically and leaves no temporary file behind", async () => {
+    const directory = await temporaryDirectory();
+    const store = new PlaytimeStore(directory);
+    await store.save(3600);
+    await store.save(7200);
+
+    const files = await readdir(directory);
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+
+    expect(files).toEqual(["playtime.v1.json"]);
+    expect(persisted).toEqual({ schemaVersion: 1, totalSeconds: 7200 });
+    expect(files.some((file) => file.endsWith(".tmp"))).toBe(false);
+  });
+
+  it("never persists a negative total", async () => {
+    const directory = await temporaryDirectory();
+    await new PlaytimeStore(directory).save(-90);
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+    expect(persisted.totalSeconds).toBe(0);
+  });
+});

--- a/tests/playtime-tracker.test.ts
+++ b/tests/playtime-tracker.test.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PlaytimeStore } from "../electron/services/playtime-store.js";
+import { elapsedSeconds, PlaytimeTracker } from "../electron/services/playtime-tracker.js";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "rotk-playtime-tracker-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+class FakeClock {
+  ns = 0n;
+
+  nowNs(): bigint {
+    return this.ns;
+  }
+
+  advanceSeconds(seconds: number): void {
+    this.ns += BigInt(seconds) * 1_000_000_000n;
+  }
+}
+
+async function trackerHarness(initialSeconds = 0) {
+  const directory = await temporaryDirectory();
+  const store = new PlaytimeStore(directory);
+  if (initialSeconds > 0) await store.save(initialSeconds);
+  const clock = new FakeClock();
+  const tracker = new PlaytimeTracker(store, { clock, persistIntervalMs: 30_000 });
+  await tracker.initialize();
+  return { directory, store, clock, tracker };
+}
+
+describe("PlaytimeTracker", () => {
+  it("starts at zero when no file exists", async () => {
+    const { tracker } = await trackerHarness();
+    expect(tracker.summary()).toEqual({ totalSeconds: 0, sessionActive: false });
+  });
+
+  it("loads an existing duration before any session", async () => {
+    const { tracker } = await trackerHarness(7260);
+    expect(tracker.summary()).toEqual({ totalSeconds: 7260, sessionActive: false });
+  });
+
+  it("adds a complete session once H1Z1 has started", async () => {
+    const { directory, clock, tracker } = await trackerHarness(120);
+    tracker.startSession();
+    clock.advanceSeconds(65);
+    await tracker.endSession();
+
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+    expect(tracker.summary()).toEqual({ totalSeconds: 185, sessionActive: false });
+    expect(persisted.totalSeconds).toBe(185);
+  });
+
+  it("does not count a second start or a second end of the same session", async () => {
+    const { clock, tracker } = await trackerHarness();
+    tracker.startSession();
+    clock.advanceSeconds(40);
+    tracker.startSession();
+    clock.advanceSeconds(20);
+    await tracker.endSession();
+    await tracker.endSession();
+
+    expect(tracker.displayedSeconds()).toBe(60);
+    expect(tracker.isSessionActive()).toBe(false);
+  });
+
+  it("keeps a zero-duration session at the previous total", async () => {
+    const { directory, tracker } = await trackerHarness(15);
+    tracker.startSession();
+    await tracker.endSession();
+
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+    expect(tracker.displayedSeconds()).toBe(15);
+    expect(persisted.totalSeconds).toBe(15);
+  });
+
+  it("never exposes a negative total when the clock moves backwards", async () => {
+    const { tracker, clock } = await trackerHarness(8);
+    tracker.startSession();
+    clock.ns = -5_000_000_000n;
+    expect(elapsedSeconds(0n, clock.nowNs())).toBe(0);
+    expect(tracker.displayedSeconds()).toBe(8);
+    await tracker.endSession();
+    expect(tracker.displayedSeconds()).toBe(8);
+  });
+
+  it("checkpoints a live session so a crash does not lose the whole duration", async () => {
+    const { directory, clock, tracker } = await trackerHarness();
+    tracker.startSession();
+    clock.advanceSeconds(90);
+    await tracker.checkpoint();
+
+    const persisted = JSON.parse(await readFile(join(directory, "playtime.v1.json"), "utf8"));
+    expect(persisted.totalSeconds).toBe(90);
+    expect(tracker.summary()).toEqual({ totalSeconds: 90, sessionActive: true });
+
+    clock.advanceSeconds(30);
+    await tracker.endSession();
+    expect(tracker.displayedSeconds()).toBe(120);
+  });
+
+  it("does not double-count time already absorbed by a checkpoint", async () => {
+    const { clock, tracker } = await trackerHarness();
+    tracker.startSession();
+    clock.advanceSeconds(50);
+    await tracker.checkpoint();
+    await tracker.checkpoint();
+    await tracker.endSession();
+    expect(tracker.displayedSeconds()).toBe(50);
+  });
+
+  it("does not count time before startSession (install, prepare, launch)", async () => {
+    const { clock, tracker } = await trackerHarness();
+    clock.advanceSeconds(180);
+    expect(tracker.displayedSeconds()).toBe(0);
+    tracker.startSession();
+    clock.advanceSeconds(12);
+    expect(tracker.displayedSeconds()).toBe(12);
+    tracker.dispose();
+    await tracker.endSession();
+  });
+
+  it("treats a save failure as non-blocking", async () => {
+    const { tracker, store, clock } = await trackerHarness();
+    vi.spyOn(store, "save").mockRejectedValueOnce(new Error("disk full"));
+    tracker.startSession();
+    clock.advanceSeconds(25);
+    await expect(tracker.endSession()).resolves.toBeUndefined();
+    expect(tracker.displayedSeconds()).toBe(25);
+  });
+});

--- a/tests/rotk-locator.test.ts
+++ b/tests/rotk-locator.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  listIsolatedRotkCandidates,
+  locateIsolatedRotkClient,
+  type RotkLocatorDependencies,
+} from "../electron/services/rotk-locator.js";
+
+function dependencies(options: {
+  existingDirectories?: string[];
+  classified?: Record<string, { root: string; kind: "direct" | "copy-required" }>;
+  marked?: string[];
+  systemDrive?: string;
+  availableDrives?: string[];
+}): RotkLocatorDependencies {
+  const existing = new Set((options.existingDirectories ?? []).map((path) => path.toLocaleLowerCase("en-US")));
+  const marked = new Set((options.marked ?? []).map((path) => path.toLocaleLowerCase("en-US")));
+  return {
+    directoryExists: async (path) => existing.has(path.toLocaleLowerCase("en-US")),
+    classify: async (path) => {
+      const mapped = options.classified?.[path] ?? options.classified?.[path.toLocaleLowerCase("en-US")];
+      if (mapped) return mapped;
+      throw new Error("not a client");
+    },
+    hasMarker: async (path) => marked.has(path.toLocaleLowerCase("en-US")),
+    systemDrive: options.systemDrive ?? "C:",
+    availableDrives: options.availableDrives ?? ["C:", "S:"],
+  };
+}
+
+describe("isolated ROTK locator", () => {
+  it("lists Games\\ROTK before a bare ROTK folder, system drive first", () => {
+    expect(listIsolatedRotkCandidates("C:", ["S:", "C:"])).toEqual([
+      "C:\\Games\\ROTK",
+      "C:\\ROTK",
+      "S:\\Games\\ROTK",
+      "S:\\ROTK",
+    ]);
+  });
+
+  it("prefers a marked ROTK install on another drive over a bare tree", async () => {
+    const located = await locateIsolatedRotkClient(dependencies({
+      existingDirectories: ["C:\\Games\\ROTK", "S:\\Games\\ROTK"],
+      classified: {
+        "C:\\Games\\ROTK": { root: "C:\\Games\\ROTK", kind: "direct" },
+        "S:\\Games\\ROTK": { root: "S:\\Games\\ROTK", kind: "direct" },
+      },
+      marked: ["S:\\Games\\ROTK"],
+    }));
+    expect(located).toBe("S:\\Games\\ROTK");
+  });
+
+  it("ignores a Steam-hosted client even if the folder exists", async () => {
+    const located = await locateIsolatedRotkClient(dependencies({
+      existingDirectories: ["S:\\Games\\ROTK"],
+      availableDrives: ["S:"],
+      classified: {
+        "S:\\Games\\ROTK": { root: "S:\\Games\\ROTK", kind: "copy-required" },
+      },
+    }));
+    expect(located).toBeNull();
+  });
+
+  it("returns the first valid standalone client when no marker exists", async () => {
+    const located = await locateIsolatedRotkClient(dependencies({
+      existingDirectories: ["S:\\Games\\ROTK"],
+      classified: {
+        "S:\\Games\\ROTK": { root: "S:\\Games\\ROTK", kind: "direct" },
+      },
+    }));
+    expect(located).toBe("S:\\Games\\ROTK");
+  });
+});


### PR DESCRIPTION
## Résultat utilisateur

Cette PR ajoute un compteur local de temps de jeu H1Z1 au footer du launcher. Il démarre à `0 h 00`, compte uniquement une session `H1Z1.exe` lancée par ROTK Launcher et affiche les heures/minutes sans modifier le bouton Play.

Elle inclut également les ajustements validés pendant les essais locaux :

- icône ROTK cohérente pour la fenêtre et les raccourcis Windows ;
- redécouverte d'une installation ROTK autonome marquée, notamment `Games\ROTK`, sans reprendre directement un client Steam ;
- meilleure lisibilité du nom de serveur dans le footer aux largeurs réduites.

## Compteur local

- stockage versionné dans `playtime.v1.json` sous le dossier `userData` Electron ;
- aucune transmission du temps de jeu à un serveur ;
- démarrage seulement après le spawn réussi de H1Z1 ;
- horloge monotone pour éviter les écarts lors d'un changement d'heure Windows ;
- sauvegarde atomique et checkpoint toutes les 30 secondes ;
- finalisation à la sortie du jeu et protection contre le double comptage ;
- fichier absent, corrompu ou valeur invalide récupéré à zéro ;
- une erreur d'écriture reste non bloquante pour le launcher et le jeu ;
- aucun accès Node ou filesystem supplémentaire exposé au renderer : le résumé passe par `LauncherSnapshot`.

## Risques et garde-fous

La découverte d'installation reste best-effort. Elle valide le marqueur et le client avant d'enregistrer le dossier, et laisse l'écran de configuration disponible en cas d'échec. Les changements ne touchent ni l'authentification, ni les tickets, ni l'attestation, ni les endpoints réseau, ni les assets H1Z1.

Le script NSIS ne change que l'icône et l'AppUserModelID des raccourcis existants.

## Vérification

Exécuté localement sous Windows x64 avec Node.js 22.16.0 et Zig 0.15.2 :

- `npm run dist` : OK ;
- typecheck TypeScript : OK ;
- Vitest : 210/210 tests réussis ;
- builds Electron et renderer : OK ;
- installateur NSIS produit : OK ;
- shim Steam recompilé : SHA-256 identique au DLL embarqué ;
- proxy et runtime Vivox empaquetés : empreintes attendues et sidecars concordants ;
- `git diff --check` : OK.

Le build local est non signé. La signature Windows, la publication GitHub Release et la mise à jour automatique de bout en bout restent du ressort du workflow officiel après revue et fusion.

## Test manuel conseillé

1. Lancer le launcher avec un profil sans `playtime.v1.json` et vérifier `0 h 00`.
2. Lancer H1Z1 depuis le launcher, attendre quelques minutes puis fermer le jeu.
3. Redémarrer le launcher et vérifier la persistance du total.
4. Vérifier que le temps ne progresse pas lorsque seul le launcher est ouvert.
5. Vérifier la reprise d'une installation ROTK autonome marquée et l'icône des raccourcis après installation.