### PR TITLE
fix(runtime): pointer le grant vocal sur une origine que chaque serveur sert vraiment

### DIFF
--- a/electron/services/runtime-config.ts
+++ b/electron/services/runtime-config.ts
@@ -37,7 +37,11 @@ export const RUNTIME_CONFIGS: Readonly<Record<ServerId, RuntimeConfig>> = Object
     // the client requires 80 — it only ever learns this URL from here, and the
     // port travels with it into every derived value below.
     gatewayOrigin: "http://162.19.94.95:8080",
-    voiceGrantOrigin: "https://vps-c717eb9e.vps.ovh.net",
+    // Le nom OVH par défaut du VPS de TEST était pinné ici : en production le
+    // certificat ne couvre pas ce nom et rien n'y sert /voice/v1, donc aucun
+    // client n'a jamais obtenu de grant. rotk.app est le vhost qui relaie
+    // désormais ces deux routes vers le Gateway en loopback.
+    voiceGrantOrigin: "https://rotk.app",
     loginHost: "162.19.94.95",
     loginPorts: [20042, 20043, 20044, 20045],
     websiteOrigin: "https://rotk.app",
@@ -51,7 +55,9 @@ export const RUNTIME_CONFIGS: Readonly<Record<ServerId, RuntimeConfig>> = Object
     // Same layout as GAME 2 on the test VPS: the game Gateway sits on 8080 and
     // Nginx terminates TLS for test.rotk.app on the same address.
     gatewayOrigin: "http://51.255.160.224:8080",
-    voiceGrantOrigin: "https://vps-c717eb9e.vps.ovh.net",
+    // Même contrat que GAME 2 : le grant se prend sur le vhost qui termine le
+    // TLS de cet environnement, jamais sur le nom OVH resté sans listener.
+    voiceGrantOrigin: "https://test.rotk.app",
     loginHost: "51.255.160.224",
     loginPorts: [20042, 20043, 20044, 20045],
     websiteOrigin: "https://test.rotk.app",

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -15,9 +15,10 @@ describe("public ROTK runtime", () => {
     // The Gateway moved off :80 so Nginx can own it for the website; the port
     // must travel into every URL the client is handed.
     expect(DEFAULT_RUNTIME_CONFIG.gatewayOrigin).toBe("http://162.19.94.95:8080");
-    expect(DEFAULT_RUNTIME_CONFIG.voiceGrantOrigin).toBe(
-      "https://vps-c717eb9e.vps.ovh.net",
-    );
+    // Le grant vocal doit viser un hôte que CET environnement sert vraiment :
+    // le nom OVH du VPS de test pinné ici auparavant n'avait ni certificat
+    // valide ni route, donc pas un seul joueur n'obtenait de voix.
+    expect(DEFAULT_RUNTIME_CONFIG.voiceGrantOrigin).toBe("https://rotk.app");
     expect(serverList(DEFAULT_RUNTIME_CONFIG)).toBe(
       "162.19.94.95:20042;162.19.94.95:20043;162.19.94.95:20044;162.19.94.95:20045",
     );
@@ -38,6 +39,7 @@ describe("public ROTK runtime", () => {
 
     expect(test.environment).toBe("development");
     expect(test.gatewayOrigin).toBe("http://51.255.160.224:8080");
+    expect(test.voiceGrantOrigin).toBe("https://test.rotk.app");
     expect(test.websiteOrigin).toBe("https://test.rotk.app");
     expect(test.launchTicketUrl).toBe("https://test.rotk.app/api/launcher/ticket");
     expect(test.attestationChallengeUrl).toBe(
@@ -93,9 +95,7 @@ describe("public ROTK runtime", () => {
     expect(args).toContain(
       "SteamGatewayUrl=http://127.0.0.1:49152/rest/auth/session/create",
     );
-    expect(args).toContain(
-      "VivoxGrantUrl=https://vps-c717eb9e.vps.ovh.net",
-    );
+    expect(args).toContain("VivoxGrantUrl=https://rotk.app");
     expect(args).toContain("CommandQueue:motd_uri=http://162.19.94.95:8080/");
     expect(args.some((argument) => (
       argument.includes("162.19.94.95:8080/rest/auth/session/create")


### PR DESCRIPTION
## Le problème

`voiceGrantOrigin` valait `https://vps-c717eb9e.vps.ovh.net` dans les **deux** entrées de `RUNTIME_CONFIGS`. C'est le nom OVH par défaut du **VPS de test** :

- il résout vers `51.255.160.224`, donc les clients de production tapaient sur le serveur de test ;
- son certificat TLS ne couvre pas ce nom — la requête échoue en `SEC_E_WRONG_PRINCIPAL` avant même d'être routée ;
- plus rien n'y sert `/voice/v1` depuis que Caddy est arrêté et que Nginx a pris `:80`/`:443`.

Résultat : **aucun joueur n'a jamais obtenu de grant vocal en jeu**, et côté serveur ça ne laissait aucune trace (le proxy Vivox fait fail-open vers le vrai service Vivox). Vérifié sur GAME 2 : zéro requête de grant reçue en 7 jours.

## Le correctif

Chaque environnement prend son grant sur le vhost qui termine son propre TLS :

| Environnement | Avant | Après |
| --- | --- | --- |
| GAME 2 | `https://vps-c717eb9e.vps.ovh.net` | `https://rotk.app` |
| Test | `https://vps-c717eb9e.vps.ovh.net` | `https://test.rotk.app` |

Ces deux vhosts relaient désormais `/voice/v1/{login,join}` vers leur Gateway en loopback — côté serveur : MzKaxD/returnoftheking#188, qui doit être déployé pour que ce changement ait un effet.

## Tests

`tests/runtime-config.test.ts` et `tests/client-config.test.ts` passent. Les assertions ont été resserrées : l'origine de chaque environnement est vérifiée explicitement, y compris celle du test qui n'était pas couverte, et `VivoxGrantUrl` est contrôlé sur la ligne de commande réellement passée au client. Le garde anti-fuite entre environnements (`never lets one server's endpoints leak into the other`) reste vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)