### PR TITLE
fix: stabilize launcher 1.4.1 runtime and update feed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
           }
 
           Write-Host "Proxy Vivox compilé depuis les sources publiques : $hash"
-          if ($hash -ne "159A7F24CA2C7E99F3EA17B9A180DAC593ED2FB92B1DB2C10D9B4EA1AE8EDEE8") {
+          if ($hash -ne "13C5E2FA603A9D31588073270F63D492141C8D3AFDDFBC2DB18856456A65CADA") {
             throw "Unexpected Vivox proxy SHA-256: $hash"
           }
           # Le sidecar alimente l'override d'attestation : s'il diverge du DLL,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           npm run build:vivox
           $proxyHash = (Get-FileHash -LiteralPath "resources\patches\vivoxsdk_x64.dll" -Algorithm SHA256).Hash
-          if ($proxyHash -ne "159A7F24CA2C7E99F3EA17B9A180DAC593ED2FB92B1DB2C10D9B4EA1AE8EDEE8") {
+          if ($proxyHash -ne "13C5E2FA603A9D31588073270F63D492141C8D3AFDDFBC2DB18856456A65CADA") {
             throw "Unexpected Vivox proxy SHA-256: $proxyHash"
           }
           # Les sidecars alimentent les overrides d'attestation embarqués :
@@ -145,7 +145,7 @@ jobs:
             Where-Object { $_.Name -eq "vivoxsdk_x64.dll" } |
             Select-Object -First 1
           $proxyHash = (Get-FileHash -LiteralPath $vivoxProxy.FullName -Algorithm SHA256).Hash
-          if ($proxyHash -ne "159A7F24CA2C7E99F3EA17B9A180DAC593ED2FB92B1DB2C10D9B4EA1AE8EDEE8") {
+          if ($proxyHash -ne "13C5E2FA603A9D31588073270F63D492141C8D3AFDDFBC2DB18856456A65CADA") {
             throw "Unexpected packaged Vivox proxy SHA-256: $proxyHash"
           }
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ La branche `new-server` cible le serveur GAME 2 ROTK `162.19.94.95` et ses liste
 
 ## Patch crouch obligatoire
 
-Le launcher 1.4.0 déploie le hook crouch ADS-safe dans son proxy
+Le launcher 1.4.1 déploie le hook crouch ADS-safe dans son proxy
 `vivoxsdk_x64.dll`. Il préserve la DLL Vivox historique, installe le runtime
 Vivox 5, puis crée `rotk-crouch-parity.ini` dans le client. Ces fichiers sont
 vérifiés et réparés pendant l’installation, lors de l’adoption d’un client

--- a/docs/CROUCH_PATCH_ROLLOUT.md
+++ b/docs/CROUCH_PATCH_ROLLOUT.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-ROTK Launcher 1.4.0 ships the ADS-safe crouch parity v11 hook inside the
+ROTK Launcher 1.4.1 ships the ADS-safe crouch parity v11 hook inside the
 open-source Vivox 5 compatibility proxy. The launcher does not patch
 `H1Z1.exe` on disk.
 
@@ -13,7 +13,7 @@ The supported client is pinned to:
 - `H1Z1.exe` SHA-256:
   `5F5A4922B0671E4ED8FD415E753BE096EF7A17E360AE80E025F11544C8DB9261`;
 - Vivox+crouch proxy SHA-256:
-  `159A7F24CA2C7E99F3EA17B9A180DAC593ED2FB92B1DB2C10D9B4EA1AE8EDEE8`.
+  `13C5E2FA603A9D31588073270F63D492141C8D3AFDDFBC2DB18856456A65CADA`.
 
 The native hook also validates the BR1315 PE timestamp, image size and target
 machine-code signatures before modifying memory. An unknown client build is
@@ -47,7 +47,7 @@ mode=patch-v2
 animation=v11-ads-safe-pose-only-js-sine-idle400-200-move250
 cameraScalePitch=disabled
 h1z1Sha256=5F5A4922B0671E4ED8FD415E753BE096EF7A17E360AE80E025F11544C8DB9261
-proxySha256=159A7F24CA2C7E99F3EA17B9A180DAC593ED2FB92B1DB2C10D9B4EA1AE8EDEE8
+proxySha256=13C5E2FA603A9D31588073270F63D492141C8D3AFDDFBC2DB18856456A65CADA
 ```
 
 The direct camera hook must remain disabled. The v11 hook replaces only the
@@ -57,11 +57,11 @@ sync-event weights, which is the ADS-safe behavior validated in the client.
 ## Release order
 
 1. Merge the launcher changes into `main`.
-2. Publish the signed `v1.4.0` launcher release and its update metadata.
+2. Publish the signed `v1.4.1` launcher release and its update metadata.
 3. Verify an existing 1.3.0 installation upgrades and repairs an old proxy.
 4. Verify one fresh Steam-copy installation and one adopted isolated client.
 5. Only after the update is publicly available, set the account/ticket
-   service minimum launcher version to `1.4.0`.
+   service minimum launcher version to `1.4.1`.
 
 The last step is what makes the patch mandatory for every server-authenticated
 player. Enabling the server gate before the release is downloadable would
@@ -78,6 +78,13 @@ block all players.
 - migration from the legacy backup name and repair after deliberate corruption
   must pass on a copy of the real BR1315 files;
 - a runtime smoke load must succeed with the official Vivox 5 DLL present.
+- the exact packaged proxy must start a real BR1315 client past
+  `cClientRunStatePreInitialize`; a `LoadLibrary`-only smoke test is not enough.
+
+The withdrawn 1.4.0 artifact started the crouch worker from `DllMain`, while
+the Windows loader lock was still held. In the combined Vivox 5 build this
+terminated BR1315 in PreInitialize (`0xc00000fd`). 1.4.1 starts the same
+ADS-safe worker only after the first proxied Vivox initialization call.
 
 ## Rollback
 

--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -134,6 +134,7 @@ const FRENCH_ERRORS = new Map<string, string>([
 ]);
 
 const DYNAMIC_ENGLISH_ERRORS: Array<[RegExp, (match: RegExpMatchArray) => string]> = [
+  [/^H1Z1 s’est fermé pendant son initialisation \(code Windows (.+)\)\.$/, (match) => `H1Z1 closed during initialization (Windows code ${match[1]}).`],
   [/^Client H1Z1 incomplet : (.+) est introuvable\.$/, (match) => `Incomplete H1Z1 client: ${match[1]} could not be found.`],
   [/^ROTK ne peut pas jouer depuis un dossier « (.+) »\. Choisis un emplacement indépendant de Steam\.$/, (match) => `ROTK cannot run from a “${match[1]}” folder. Choose a location outside Steam.`],
   [/^Cet emplacement renvoie physiquement vers « (.+) » et ne peut pas être utilisé\.$/, (match) => `This location physically resolves to “${match[1]}” and cannot be used.`],

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -17,6 +17,8 @@ import {
 } from "./launch-ticket.js";
 import { deployVivoxCompatibility } from "./vivox-client.js";
 
+const GAME_STARTUP_STABILITY_MS = 3_000;
+
 /**
  * What one attestation attempt produced.
  * - `attested`: a block to carry with the ticket request.
@@ -203,6 +205,48 @@ function validateVoiceGrantOrigin(value: string): string {
   return parsed.origin;
 }
 
+function windowsExitCode(code: number | null): string {
+  if (code === null) return "inconnu";
+  return `0x${(code >>> 0).toString(16).padStart(8, "0").toUpperCase()}`;
+}
+
+function waitForStableStartup(
+  child: ChildProcess,
+  durationMs = GAME_STARTUP_STABILITY_MS,
+): Promise<void> {
+  if (child.exitCode !== null) {
+    return Promise.reject(new Error(
+      `H1Z1 s’est fermé pendant son initialisation (code Windows ${windowsExitCode(child.exitCode)}).`,
+    ));
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(
+        `H1Z1 s’est fermé pendant son initialisation (code Windows ${windowsExitCode(code)}).`,
+      ));
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(new Error(`Windows n’a pas pu initialiser H1Z1 : ${error.message}`));
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, durationMs);
+    child.once("exit", onExit);
+    child.once("error", onError);
+    // Cover the narrow race where the process exits between the initial
+    // exitCode check and listener registration.
+    if (child.exitCode !== null) onExit(child.exitCode);
+  });
+}
+
 export class GameLauncher {
   private child: ChildProcess | null = null;
 
@@ -308,6 +352,11 @@ export class GameLauncher {
       };
       child.once("exit", (code) => finalize(code));
       child.once("error", () => finalize(null));
+      // Do not report IN GAME for a native process that dies in its loader or
+      // PreInitialize path. This was the visible failure mode of launcher
+      // 1.4.0: H1Z1 exited with 0xc00000fd immediately after spawn, while the
+      // renderer had already switched to the running state.
+      await waitForStableStartup(child);
       child.unref();
       return child.pid;
     } catch (error) {
@@ -324,4 +373,5 @@ export const gameLauncherInternals = {
   prepareClient,
   buildLaunchArguments,
   validateVoiceGrantOrigin,
+  windowsExitCode,
 };

--- a/electron/services/update-feed.ts
+++ b/electron/services/update-feed.ts
@@ -3,25 +3,22 @@ import { dirname, join } from "node:path";
 import type { PublishedUpdate } from "../../shared/contracts.js";
 import { WEBSITE_ORIGIN } from "../constants.js";
 
-const FIRESTORE_QUERY_URL =
-  "https://firestore.googleapis.com/v1/projects/rotk-project/databases/(default)/documents:runQuery";
+const UPDATE_FEED_URL = `${WEBSITE_ORIGIN}/api/updates`;
 const MAX_FEED_BYTES = 1_000_000;
 
-interface FirestoreValue {
-  stringValue?: string;
-  timestampValue?: string;
-  nullValue?: null;
+interface PublishedUpdateApiItem {
+  id?: unknown;
+  type?: unknown;
+  title?: unknown;
+  summary?: unknown;
+  version?: unknown;
+  category?: unknown;
+  coverImage?: unknown;
+  publishedAt?: unknown;
 }
 
-interface FirestoreQueryRow {
-  document?: {
-    name?: string;
-    fields?: Record<string, FirestoreValue>;
-  };
-}
-
-function readString(fields: Record<string, FirestoreValue>, key: string): string {
-  return fields[key]?.stringValue?.trim() ?? "";
+function readString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function normalizeCoverImage(value: string): string {
@@ -34,18 +31,36 @@ function normalizeCoverImage(value: string): string {
   return "";
 }
 
-function parseRows(value: unknown): PublishedUpdate[] {
-  if (!Array.isArray(value)) throw new Error("Unexpected Firestore response");
-  const updates: PublishedUpdate[] = [];
+/**
+ * Keeps the newest patch note first so the launcher always opens on the most
+ * recent game release. The second carousel slot remains available for the
+ * newest other publication (or the previous patch note).
+ */
+function selectLauncherUpdates(updates: PublishedUpdate[]): PublishedUpdate[] {
+  const sorted = [...updates].sort(
+    (left, right) => Date.parse(right.publishedAt) - Date.parse(left.publishedAt),
+  );
+  const latestPatch = sorted.find((update) => update.type === "patch");
+  if (!latestPatch) return sorted.slice(0, 2);
+  return [latestPatch, ...sorted.filter((update) => update.id !== latestPatch.id)].slice(0, 2);
+}
 
-  for (const row of value as FirestoreQueryRow[]) {
-    const fields = row.document?.fields;
-    const name = row.document?.name;
-    if (!fields || !name) continue;
-    const id = name.split("/").at(-1) ?? "";
-    const type = readString(fields, "type");
-    const title = readString(fields, "title");
-    const publishedAt = fields.publishedAt?.timestampValue ?? "";
+function parseFeed(value: unknown): PublishedUpdate[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Unexpected update feed response");
+  }
+
+  const entries = (value as { updates?: unknown }).updates;
+  if (!Array.isArray(entries)) throw new Error("Unexpected update feed response");
+
+  const updates: PublishedUpdate[] = [];
+  for (const entry of entries as PublishedUpdateApiItem[]) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+
+    const id = readString(entry.id);
+    const type = readString(entry.type);
+    const title = readString(entry.title);
+    const publishedAt = readString(entry.publishedAt);
     if (
       !id ||
       !title ||
@@ -60,18 +75,16 @@ function parseRows(value: unknown): PublishedUpdate[] {
       id,
       type,
       title: title.slice(0, 120),
-      summary: readString(fields, "summary").slice(0, 360),
-      version: readString(fields, "version") || null,
-      category: readString(fields, "category").slice(0, 64),
-      coverImageUrl: normalizeCoverImage(readString(fields, "coverImage")),
+      summary: readString(entry.summary).slice(0, 360),
+      version: readString(entry.version) || null,
+      category: readString(entry.category).slice(0, 64),
+      coverImageUrl: normalizeCoverImage(readString(entry.coverImage)),
       publishedAt,
       siteUrl: `${WEBSITE_ORIGIN}/updates/${encodeURIComponent(id)}`,
     });
   }
 
-  return updates
-    .sort((left, right) => Date.parse(right.publishedAt) - Date.parse(left.publishedAt))
-    .slice(0, 2);
+  return selectLauncherUpdates(updates);
 }
 
 function isCachedUpdate(value: unknown): value is PublishedUpdate {
@@ -92,7 +105,8 @@ export class UpdateFeedService {
   private readonly cachePath: string;
 
   constructor(userDataDirectory: string) {
-    this.cachePath = join(userDataDirectory, "updates-cache.v1.json");
+    // v2 deliberately ignores the old Firestore-backed cache.
+    this.cachePath = join(userDataDirectory, "updates-cache.v2.json");
   }
 
   async getLatest(): Promise<PublishedUpdate[]> {
@@ -101,25 +115,22 @@ export class UpdateFeedService {
       const timeout = setTimeout(() => controller.abort(), 7_000);
       let response: Response;
       try {
-        response = await fetch(FIRESTORE_QUERY_URL, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            structuredQuery: {
-              from: [{ collectionId: "publishedUpdates" }],
-              orderBy: [{ field: { fieldPath: "publishedAt" }, direction: "DESCENDING" }],
-              limit: 2,
-            },
-          }),
+        response = await fetch(UPDATE_FEED_URL, {
+          method: "GET",
+          headers: { accept: "application/json" },
           signal: controller.signal,
         });
       } finally {
         clearTimeout(timeout);
       }
       if (!response.ok) throw new Error(`Feed HTTP ${response.status}`);
+      const responseUrl = new URL(response.url || UPDATE_FEED_URL);
+      if (responseUrl.protocol !== "https:" || responseUrl.origin !== WEBSITE_ORIGIN) {
+        throw new Error("Feed redirected outside rotk.app");
+      }
       const body = await response.text();
       if (Buffer.byteLength(body, "utf8") > MAX_FEED_BYTES) throw new Error("Feed too large");
-      const updates = parseRows(JSON.parse(body));
+      const updates = parseFeed(JSON.parse(body));
       if (updates.length === 0) throw new Error("Feed empty");
       await this.writeCache(updates);
       return updates;
@@ -146,7 +157,7 @@ export class UpdateFeedService {
 }
 
 export const updateFeedInternals = {
-  parseRows,
+  parseFeed,
   normalizeCoverImage,
-  queryUrl: FIRESTORE_QUERY_URL,
+  feedUrl: UPDATE_FEED_URL,
 };

--- a/electron/services/vivox-client.ts
+++ b/electron/services/vivox-client.ts
@@ -9,7 +9,7 @@ export const VIVOX_STOCK_V4_SHA256 =
 export const VIVOX_STOCK_V5_SHA256 =
   "33a7f704eda23dda9ccbd9eba1fda2f0589211e9c61ec9d1f9c797acc624ea44";
 export const VIVOX_PROXY_SHA256 =
-  "159a7f24ca2c7e99f3ea17b9a180dac593ed2fb92b1db2c10d9b4ea1ae8edee8";
+  "13c5e2fa603a9d31588073270f63d492141c8d3afddfbc2db18856456a65cada";
 export const CROUCH_PARITY_MARKER_NAME = "rotk-crouch-parity.ini";
 
 const CROUCH_CLIENT_BUILD_ID = "h1z1-1.0.326.439939";

--- a/native/vivoxproxy/vivoxsdk_x64_proxy.c
+++ b/native/vivoxproxy/vivoxsdk_x64_proxy.c
@@ -587,6 +587,14 @@ static BOOL CALLBACK initialize_original(PINIT_ONCE once,
     proxy_trace_once(
         TRACE_ORIGINAL_READY,
         "[rotk-vivoxproxy] original init: ready");
+    /*
+     * Never create the crouch worker from DllMain.  In the combined Vivox 5
+     * proxy, starting it while the Windows loader lock is held terminates
+     * BR1315 in PreInitialize (0xc00000fd).  The first proxied Vivox call is
+     * made after loader initialization and before character animation assets
+     * are used, which is the safe and deterministic start point.
+     */
+    crouch_parity_start();
     return TRUE;
 }
 
@@ -2697,7 +2705,6 @@ BOOL WINAPI DllMain(HINSTANCE instance,
     if (reason == DLL_PROCESS_ATTACH) {
         g_proxy_module = instance;
         DisableThreadLibraryCalls(instance);
-        crouch_parity_start();
     }
     return TRUE;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/resources/patches/vivoxsdk_x64.dll.sha256
+++ b/resources/patches/vivoxsdk_x64.dll.sha256
@@ -1,1 +1,1 @@
-159a7f24ca2c7e99f3ea17b9a180dac593ed2fb92b1db2c10d9b4ea1ae8edee8 *vivoxsdk_x64.dll
+13c5e2fa603a9d31588073270f63d492141c8d3afddfbc2db18856456a65cada *vivoxsdk_x64.dll

--- a/tests/native-vivox-runtime.test.ts
+++ b/tests/native-vivox-runtime.test.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { VIVOX_PROXY_SHA256 } from "../electron/services/vivox-client.js";
+
+const repositoryRoot = resolve(import.meta.dirname, "..");
+
+describe("native Vivox+crouch runtime contract", () => {
+  it("starts crouch only after the Windows loader phase", async () => {
+    const source = await readFile(
+      resolve(repositoryRoot, "native/vivoxproxy/vivoxsdk_x64_proxy.c"),
+      "utf8",
+    );
+    const initializeStart = source.indexOf("static BOOL CALLBACK initialize_original");
+    const initializeEnd = source.indexOf("static BOOL bearer_is_safe", initializeStart);
+    const dllMainStart = source.indexOf("BOOL WINAPI DllMain");
+
+    expect(initializeStart).toBeGreaterThanOrEqual(0);
+    expect(initializeEnd).toBeGreaterThan(initializeStart);
+    expect(dllMainStart).toBeGreaterThanOrEqual(0);
+    expect(source.slice(initializeStart, initializeEnd)).toContain(
+      "crouch_parity_start();",
+    );
+    expect(source.slice(dllMainStart)).not.toContain("crouch_parity_start();");
+  });
+
+  it("keeps the bundled binary, deployment policy and attestation sidecar aligned", async () => {
+    const binaryPath = resolve(
+      repositoryRoot,
+      "resources/patches/vivoxsdk_x64.dll",
+    );
+    const [binary, sidecar] = await Promise.all([
+      readFile(binaryPath),
+      readFile(`${binaryPath}.sha256`, "utf8"),
+    ]);
+    const bundledHash = createHash("sha256").update(binary).digest("hex");
+
+    expect(bundledHash).toBe(VIVOX_PROXY_SHA256);
+    expect(sidecar.trim().split(/\s+/u)[0]).toBe(VIVOX_PROXY_SHA256);
+  });
+});

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -134,4 +134,14 @@ describe("public ROTK runtime", () => {
     expect(environment.H1Z1_OVERRIDE_STEAMID).toBe("76561198000000001");
     expect(environment.H1Z1_OVERRIDE_PERSONA).toBe("ROTK Player");
   });
+
+  it("formats native startup failures as unsigned Windows exception codes", () => {
+    expect(gameLauncherInternals.windowsExitCode(-1_073_741_571)).toBe(
+      "0xC00000FD",
+    );
+    expect(gameLauncherInternals.windowsExitCode(-1_073_741_819)).toBe(
+      "0xC0000005",
+    );
+    expect(gameLauncherInternals.windowsExitCode(null)).toBe("inconnu");
+  });
 });

--- a/tests/update-feed.test.ts
+++ b/tests/update-feed.test.ts
@@ -1,62 +1,81 @@
 import { describe, expect, it } from "vitest";
 import { updateFeedInternals } from "../electron/services/update-feed.js";
 
-function row(
+function update(
   id: string,
-  fields: Record<string, { stringValue?: string; timestampValue?: string }>,
-): unknown {
+  fields: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
-    document: {
-      name: `projects/rotk-project/databases/(default)/documents/publishedUpdates/${id}`,
-      fields,
-    },
+    id,
+    type: "patch",
+    title: id,
+    summary: "Published on rotk.app",
+    version: "1.0.0",
+    publishedAt: "2026-07-17T13:53:00.000Z",
+    ...fields,
   };
 }
 
 describe("ROTK update feed parsing", () => {
-  it("uses the public read-only endpoint without embedding an API key", () => {
-    const url = new URL(updateFeedInternals.queryUrl);
-    expect(url.origin).toBe("https://firestore.googleapis.com");
-    expect(url.pathname).toContain("/projects/rotk-project/");
+  it("uses the official rotk.app API instead of Firebase", () => {
+    const url = new URL(updateFeedInternals.feedUrl);
+    expect(url.origin).toBe("https://rotk.app");
+    expect(url.pathname).toBe("/api/updates");
     expect(url.search).toBe("");
+    expect(updateFeedInternals.feedUrl).not.toContain("firebase");
+    expect(updateFeedInternals.feedUrl).not.toContain("firestore");
   });
 
-  it("keeps only the two newest supported publications", () => {
-    const parsed = updateFeedInternals.parseRows([
-      row("old-patch", {
-        type: { stringValue: "patch" },
-        title: { stringValue: "Old patch" },
-        summary: { stringValue: "Older" },
-        publishedAt: { timestampValue: "2026-07-15T10:00:00.000Z" },
-      }),
-      row("latest-dev", {
-        type: { stringValue: "dev" },
-        title: { stringValue: "Latest dev update" },
-        summary: { stringValue: "Newest" },
-        coverImage: { stringValue: "https://rotk.app/images/atv-run.jpg" },
-        publishedAt: { timestampValue: "2026-07-17T13:53:00.000Z" },
-      }),
-      row("middle-patch", {
-        type: { stringValue: "patch" },
-        title: { stringValue: "Middle patch" },
-        version: { stringValue: "1.0.0" },
-        publishedAt: { timestampValue: "2026-07-17T13:12:00.000Z" },
-      }),
-      row("ignored-news", {
-        type: { stringValue: "news" },
-        title: { stringValue: "Unsupported" },
-        publishedAt: { timestampValue: "2026-07-18T00:00:00.000Z" },
-      }),
-      row("invalid-date", {
-        type: { stringValue: "dev" },
-        title: { stringValue: "Malformed publication" },
-        publishedAt: { timestampValue: "not-a-date" },
-      }),
-    ]);
+  it("keeps the newest patch note first and at most two publications", () => {
+    const parsed = updateFeedInternals.parseFeed({
+      updates: [
+        update("old-patch", { publishedAt: "2026-07-15T10:00:00.000Z" }),
+        update("latest-dev", {
+          type: "dev",
+          title: "Latest dev update",
+          coverImage: "/images/atv-run.jpg",
+          publishedAt: "2026-07-18T13:53:00.000Z",
+        }),
+        update("latest-patch", {
+          title: "Latest patch",
+          version: "1.3.32",
+          publishedAt: "2026-07-17T13:12:00.000Z",
+        }),
+        update("ignored-news", {
+          type: "news",
+          title: "Unsupported",
+          publishedAt: "2026-07-19T00:00:00.000Z",
+        }),
+        update("invalid-date", { publishedAt: "not-a-date" }),
+      ],
+    });
 
-    expect(parsed.map((item) => item.id)).toEqual(["latest-dev", "middle-patch"]);
-    expect(parsed[0].siteUrl).toBe("https://rotk.app/updates/latest-dev");
-    expect(parsed[0].coverImageUrl).toBe("https://rotk.app/images/atv-run.jpg");
+    expect(parsed.map((item) => item.id)).toEqual(["latest-patch", "latest-dev"]);
+    expect(parsed[0].siteUrl).toBe("https://rotk.app/updates/latest-patch");
+    expect(parsed[1].coverImageUrl).toBe("https://rotk.app/images/atv-run.jpg");
+  });
+
+  it("parses the nullable fields returned by the VPS API", () => {
+    const parsed = updateFeedInternals.parseFeed({
+      updates: [
+        update("patch-1-3-32", {
+          title: "Patch Note — SAISON 0 !",
+          category: null,
+          coverImage: "/images/combat-smoke.jpg",
+          version: "1.3.32",
+          publishedAt: "2026-08-15T22:31:45.617Z",
+        }),
+      ],
+    });
+
+    expect(parsed[0]).toMatchObject({
+      id: "patch-1-3-32",
+      type: "patch",
+      category: "",
+      version: "1.3.32",
+      coverImageUrl: "https://rotk.app/images/combat-smoke.jpg",
+      siteUrl: "https://rotk.app/updates/patch-1-3-32",
+    });
   });
 
   it("does not allow third-party or insecure cover images", () => {
@@ -67,20 +86,27 @@ describe("ROTK update feed parsing", () => {
     );
   });
 
-  it("bounds text and URL-encodes Firestore document ids", () => {
-    const parsed = updateFeedInternals.parseRows([
-      row("dev update #1", {
-        type: { stringValue: "dev" },
-        title: { stringValue: "T".repeat(200) },
-        summary: { stringValue: "S".repeat(500) },
-        category: { stringValue: "C".repeat(100) },
-        publishedAt: { timestampValue: "2026-07-17T13:53:00.000Z" },
-      }),
-    ]);
+  it("bounds text and URL-encodes update ids", () => {
+    const parsed = updateFeedInternals.parseFeed({
+      updates: [
+        update("patch update #1", {
+          title: "T".repeat(200),
+          summary: "S".repeat(500),
+          category: "C".repeat(100),
+        }),
+      ],
+    });
 
     expect(parsed[0].title).toHaveLength(120);
     expect(parsed[0].summary).toHaveLength(360);
     expect(parsed[0].category).toHaveLength(64);
-    expect(parsed[0].siteUrl).toBe("https://rotk.app/updates/dev%20update%20%231");
+    expect(parsed[0].siteUrl).toBe("https://rotk.app/updates/patch%20update%20%231");
+  });
+
+  it("rejects malformed top-level responses", () => {
+    expect(() => updateFeedInternals.parseFeed([])).toThrow("Unexpected update feed response");
+    expect(() => updateFeedInternals.parseFeed({ updates: null })).toThrow(
+      "Unexpected update feed response",
+    );
   });
 });


### PR DESCRIPTION
Fixes the H1Z1 startup crash introduced by v1.4.0 by starting crouch parity after the Windows loader phase. Adds an early native-crash guard and migrates launcher patch notes from Firestore to the official rotk.app API. Validation: 23 test files / 191 tests passed, production NSIS build passed, live rotk.app feed returned patch-1-3-32.