### PR TITLE
fix: repair client drift and ignore unused LaunchPad runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ déjà animé.
 Le séquencement de release, le verrou serveur et le rollback sont documentés
 dans [`docs/CROUCH_PATCH_ROLLOUT.md`](docs/CROUCH_PATCH_ROLLOUT.md).
 
+## Réparation des assets 1.4.5
+
+Le launcher 1.4.5 re-hashe désormais à chaque synchronisation les assets
+distribués comme fichiers autonomes, même lorsque leur taille n’a pas changé.
+Cela couvre notamment `Weapons.bnk_pc` et `Weapons_SFX.bnk_pc` du feed 1.5.0 :
+le lancement normal comme **Vérifier les fichiers** restaurent automatiquement
+la copie officielle si une variante vanilla de même taille l’a remplacée.
+
 ## Retrait du proxy gameplay 1.4.3
 
 Le launcher 1.4.4 ne distribue et ne charge plus le proxy DirectInput gameplay.

--- a/electron/services/asset-sync.ts
+++ b/electron/services/asset-sync.ts
@@ -498,7 +498,11 @@ export class AssetSyncService {
         pending.push(asset);
         continue;
       }
-      if (await this.recordNeedsRepair(root, record, options.thorough ?? false)) pending.push(asset);
+      // Standalone files are cheap enough to hash on every launch and may be
+      // replaced by a same-size vanilla variant. ZIP-backed packs keep the
+      // fast size check unless the player explicitly runs Verify files.
+      const thorough = options.thorough === true || asset.type === "file";
+      if (await this.recordNeedsRepair(root, record, thorough)) pending.push(asset);
       else keptRecords.push(record);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rotk-launcher",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rotk-launcher",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotk-launcher",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Open-source launcher for Return of the King",
   "author": "Return of the King contributors",
   "license": "GPL-3.0-or-later",

--- a/scripts/generate-base-manifest.mjs
+++ b/scripts/generate-base-manifest.mjs
@@ -40,6 +40,9 @@ const EXCLUDED_PATHS = new Set([
   // Per-player, rewritten by the game itself.
   "useroptions.ini",
   "inputprofile_user.xml",
+  // Daybreak updates this unused bootstrap independently. ROTK starts
+  // H1Z1.exe directly; the game executable remains attested.
+  "launchpad.exe",
   // Rewritten by the launcher before every launch.
   "clientconfig.ini",
   "battleye/beclient_x64.cfg",
@@ -51,7 +54,7 @@ const EXCLUDED_PATHS = new Set([
   "steam_api64.original.dll",
   "vivoxsdk_x64.original.dll",
 ]);
-const EXCLUDED_PREFIXES = ["logs/", "crashes/", "cache/", "battleye/"];
+const EXCLUDED_PREFIXES = ["logs/", "crashes/", "cache/", "battleye/", "launchpad.libs/"];
 const EXCLUDED_SUFFIXES = [".log", ".dmp", ".original"];
 
 function parseArgs(argv) {

--- a/shared/attestation.ts
+++ b/shared/attestation.ts
@@ -60,8 +60,10 @@ export const TRUSTED_ATTESTATION_KEYS: Readonly<Record<string, string>> = Object
  *      settings, keybinds), or is rewritten on every launch by the launcher; AND
  *   2. it cannot carry gameplay content or executable code.
  *
- * No `.pack2`, no `.exe`, and no `.dll` the game can load may ever be added
- * here (a `.original.dll` vanilla backup is the sole tolerated .dll shape):
+ * No `.pack2`, no game-loaded `.exe`, and no `.dll` the game can load may ever
+ * be added here (a `.original.dll` vanilla backup is the sole tolerated .dll
+ * shape). The one executable exception is Daybreak's unused, independently
+ * updated LaunchPad bootstrap; ROTK starts H1Z1.exe directly:
  * those are exactly what attestation exists to protect. `steam_api64.dll` and
  * `vivoxsdk_x64.dll` are NOT excluded — the launcher replaces them with its
  * own artifacts, so they are verified against those hashes instead (see
@@ -75,6 +77,9 @@ export const ATTESTATION_EXCLUDED_PATHS: ReadonlySet<string> = new Set([
   // Per-player, rewritten by the game itself.
   "useroptions.ini",
   "inputprofile_user.xml",
+  // Daybreak updates this unused bootstrap independently. ROTK launches
+  // H1Z1.exe directly; the game executable remains attested.
+  "launchpad.exe",
   // Rewritten by the launcher before every launch.
   "clientconfig.ini",
   "battleye/beclient_x64.cfg",
@@ -95,6 +100,9 @@ export const ATTESTATION_EXCLUDED_PREFIXES: readonly string[] = [
   // BattlEye updates its own client binaries out of band; attesting them would
   // reject players mid-update. Deliberate gap — BattlEye guards itself.
   "battleye/",
+  // CEF runtime owned by the unused Daybreak LaunchPad bootstrap. Keep the
+  // in-game Browser/Resources tree attested.
+  "launchpad.libs/",
 ];
 
 /** Filename suffixes never part of the shipped tree. */

--- a/tests/asset-sync.test.ts
+++ b/tests/asset-sync.test.ts
@@ -306,7 +306,7 @@ describe("ROTK asset sync", () => {
     expect(calls).toEqual([FEED_URL]);
   });
 
-  it("verify() detects silent corruption and reinstalls the asset", async () => {
+  it("normal sync detects same-size drift in a standalone file asset", async () => {
     const { userData, root } = await setup();
     const payload = Buffer.from("pristine-content");
     const feed = manifest([assetEntry("check.dat", payload)]);
@@ -316,11 +316,45 @@ describe("ROTK asset sync", () => {
     });
 
     await sync.sync(root);
-    // Same size, different bytes: only a thorough re-hash can catch it.
+    // Same size, different bytes: standalone files are still hashed during the
+    // normal pre-launch sync so attestation never sees the stale copy.
     await writeFile(join(root, "check.dat"), "tampered-content");
-    expect(await sync.sync(root)).toEqual({ status: "up-to-date", packVersion: "1.0.0" });
-    expect(await sync.verify(root)).toEqual({ status: "updated", packVersion: "1.0.0" });
+    expect(await sync.sync(root)).toEqual({ status: "updated", packVersion: "1.0.0" });
     expect(await readFile(join(root, "check.dat"), "utf8")).toBe("pristine-content");
+  });
+
+  it("Verify files repairs both 1.5.0 weapon banks after same-size drift", async () => {
+    const { userData, root } = await setup();
+    const audioRoot = join(root, "Resources", "Audio", "pc9");
+    await mkdir(audioRoot, { recursive: true });
+
+    const weapons = Buffer.from("rotk-weapons-bank");
+    const weaponsSfx = Buffer.from("rotk-weapons-sfx-bank");
+    const feed = manifest([
+      assetEntry("weapons_bank_pc9", weapons, {
+        version: "1.5.0",
+        url: "https://github.com/h1z1rotk/assets/releases/download/assets-v1.5.0/Weapons.bnk_pc",
+        installPath: "Resources/Audio/pc9/Weapons.bnk_pc",
+      }),
+      assetEntry("weapons_sfx_bank_pc9", weaponsSfx, {
+        version: "1.5.0",
+        url: "https://github.com/h1z1rotk/assets/releases/download/assets-v1.5.0/Weapons_SFX.bnk_pc",
+        installPath: "Resources/Audio/pc9/Weapons_SFX.bnk_pc",
+      }),
+    ], "1.5.0");
+    const sync = service(userData, {
+      [FEED_URL]: () => new Response(JSON.stringify(feed)),
+      [feed.assets[0].url]: () => new Response(weapons),
+      [feed.assets[1].url]: () => new Response(weaponsSfx),
+    });
+
+    await sync.sync(root);
+    await writeFile(join(audioRoot, "Weapons.bnk_pc"), Buffer.alloc(weapons.length, 0x76));
+    await writeFile(join(audioRoot, "Weapons_SFX.bnk_pc"), Buffer.alloc(weaponsSfx.length, 0x73));
+
+    expect(await sync.verify(root)).toEqual({ status: "updated", packVersion: "1.5.0" });
+    expect(await readFile(join(audioRoot, "Weapons.bnk_pc"))).toEqual(weapons);
+    expect(await readFile(join(audioRoot, "Weapons_SFX.bnk_pc"))).toEqual(weaponsSfx);
   });
 
   it("never installs a download whose SHA-256 does not match the manifest", async () => {

--- a/tests/attestation.test.ts
+++ b/tests/attestation.test.ts
@@ -6,6 +6,7 @@ import {
   challengeSigningInput,
   computeAttestationEvidence,
   computeManifestRoot,
+  isAttestationExcluded,
   isManifestPath,
   isSha256Hex,
   manifestPathKey,
@@ -140,12 +141,13 @@ const CANONICAL = {
     "clientconfig.ini",
     "clientconfig.original.ini",
     "inputprofile_user.xml",
+    "launchpad.exe",
     "steam_api64.original.dll",
     "steam_persona_name.txt",
     "useroptions.ini",
     "vivoxsdk_x64.original.dll",
   ],
-  excludedPrefixes: ["battleye/", "cache/", "crashes/", "logs/"],
+  excludedPrefixes: ["battleye/", "cache/", "crashes/", "launchpad.libs/", "logs/"],
   excludedSuffixes: [".dmp", ".log", ".original"],
 };
 
@@ -177,10 +179,15 @@ describe("canonical exclusion contract", () => {
   it("never excludes gameplay content or the shim", () => {
     for (const path of CANONICAL.excludedPaths) {
       expect(path).not.toMatch(/\.pack2$/);
-      expect(path).not.toMatch(/\.exe$/);
+      if (path.endsWith(".exe")) expect(path).toBe("launchpad.exe");
       if (path.endsWith(".dll")) expect(path).toMatch(/\.original\.dll$/);
     }
     expect(CANONICAL.excludedPaths).not.toContain("steam_api64.dll");
+    expect(isAttestationExcluded("LaunchPad.exe")).toBe(true);
+    expect(isAttestationExcluded("LaunchPad.libs/libcef.dll")).toBe(true);
+    expect(isAttestationExcluded("LaunchPad.bat")).toBe(false);
+    expect(isAttestationExcluded("H1Z1.exe")).toBe(false);
+    expect(isAttestationExcluded("Browser/Resources/libcef.dll")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Urgent production hotfix

- bumps the launcher to 1.4.5
- re-hashes standalone feed files on normal sync, repairing same-size audio drift
- excludes only the unused Daybreak LaunchPad.exe and LaunchPad.libs/ runtime from attestation
- keeps H1Z1.exe, Browser/Resources, assets and runtime overrides protected
- adds regression coverage for both PS3 weapon banks and the narrow exclusion boundary

## Validation

- npm run build (197 tests passed, typecheck and production builds passed)
- targeted attestation and asset-sync tests passed
- official Vivox proxy/runtime preparation and hash checks passed