### PR TITLE
fix(client-config): point GameCrashUrl, PetitionUri and the crash reporter to rotk.app

### DIFF
--- a/electron/services/client-config.ts
+++ b/electron/services/client-config.ts
@@ -90,9 +90,45 @@ export function synchronizeClientConfig(
       key: "Url",
       value: `${runtime.gatewayOrigin}/h1z1xx/live/`,
     },
+    ...webEndpointDirectives(runtime),
   ];
   for (const directive of directives) synchronized = upsertIniDirective(synchronized, directive);
   return synchronized;
+}
+
+/**
+ * Where `[CrashReporter] Address` points instead of recap.daybreakgames.com:
+ * loopback is refused instantly and resolves without a DNS query, and nothing
+ * on the player's machine listens there. An empty value has unknown semantics
+ * in the stock client, so it is never used.
+ */
+export const CRASH_REPORTER_SINKHOLE_ADDRESS = "127.0.0.1:15081";
+
+/**
+ * Everything the client opens in a browser or uploads on its own. The stock
+ * INI names h1z1.com for the game-error page (the client appends the code and
+ * `&info=<detail>`, which for G9 carries the gateway ticket), custhelp.com for
+ * the help button (`%s` is the locale) and recap.daybreakgames.com for crash
+ * dumps. None of it may leave for Daybreak: the website serves the pages and
+ * loopback swallows the dumps. Shared by the INI and the launch arguments so
+ * the two can never disagree.
+ */
+export function webEndpointDirectives(runtime: RuntimeConfig): IniDirective[] {
+  return [
+    {
+      section: "WebResources",
+      key: "GameCrashUrl",
+      value: `${runtime.websiteOrigin}/game-error?code=G`,
+    },
+    { section: "Help", key: "PetitionUri", value: `${runtime.websiteOrigin}/support?locale=%s` },
+    { section: "CrashReporter", key: "Address", value: CRASH_REPORTER_SINKHOLE_ADDRESS },
+  ];
+}
+
+export function webEndpointLaunchArguments(runtime: RuntimeConfig): string[] {
+  return webEndpointDirectives(runtime).map(
+    (directive) => `${directive.section}:${directive.key}=${directive.value}`,
+  );
 }
 
 export function validateLocalCreateSessionUrl(value: string): string {

--- a/electron/services/game-launcher.ts
+++ b/electron/services/game-launcher.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import type { InstalledClientConfig, LauncherConfig } from "./config-store.js";
 import type { RuntimeConfig } from "./runtime-config.js";
 import { serverList } from "./runtime-config.js";
-import { synchronizeClientConfig, validateLocalCreateSessionUrl } from "./client-config.js";
+import {
+  synchronizeClientConfig,
+  validateLocalCreateSessionUrl,
+  webEndpointLaunchArguments,
+} from "./client-config.js";
 import { validateInstallDestination } from "./path-policy.js";
 import type { PlayerIdentity } from "./player-identity.js";
 import { startLocalSessionGateway } from "./session-gateway.js";
@@ -178,6 +182,7 @@ function buildLaunchArguments(
     `CommandQueue:cb_uri=${runtime.gatewayOrigin}/`,
     `CommandQueue:eula_uri=${runtime.gatewayOrigin}/`,
     `LaunchTelemetry:Url=${runtime.gatewayOrigin}/h1z1xx/live/`,
+    ...webEndpointLaunchArguments(runtime),
     "Logging:ConsoleLogLevel=999",
     "Logging:FileLogLevel=999",
     "Logging:LocalLogLevel=999",

--- a/tests/client-config.test.ts
+++ b/tests/client-config.test.ts
@@ -36,6 +36,13 @@ describe("ClientConfig synchronization", () => {
       "[LaunchTelemetry]",
       "Url=http://old.invalid/telemetry",
       "",
+      "[CrashReporter]",
+      "Address=recap.daybreakgames.com:15081",
+      "NoUploadFromInit=1",
+      "",
+      "[WebResources]",
+      "GameCrashUrl=https://www.h1z1.com/king-of-the-kill/game-error?code=G",
+      "",
     ].join("\r\n");
 
     const once = synchronizeClientConfig(original, runtime, localCreateSessionUrl);
@@ -49,6 +56,40 @@ describe("ClientConfig synchronization", () => {
     expect(once).toContain(`SteamGatewayUrl=${localCreateSessionUrl}`);
     expect(once).not.toContain(authKey);
     expect(once).toContain("SoeAuthTicketUrl=https://gateway.rotk.app/rest/client/session/create");
+    expect(once).toContain("[WebResources]\r\nGameCrashUrl=https://rotk.app/game-error?code=G");
+    expect(once).toContain("[CrashReporter]\r\nAddress=127.0.0.1:15081\r\nNoUploadFromInit=1");
+    expect(once).toContain("[Help]\r\nPetitionUri=https://rotk.app/support?locale=%s");
+  });
+
+  it("leaves no Daybreak endpoint the client could open or upload to", () => {
+    // The stock ClientConfig.ini shipped with the game, endpoint lines only.
+    const stock = [
+      "[INGAMEPURCHASE]",
+      "SoeAuthTicketUrl=https://partner.soe.platformpublishing.com/rest/client/session/create",
+      "",
+      "[CrashReporter]",
+      "Address=recap.daybreakgames.com:15081",
+      "NoUploadFromInit=1",
+      "",
+      "[WebResources]",
+      "GameCrashUrl=https://www.h1z1.com/king-of-the-kill/game-error?code=G",
+      "",
+      "[Help]",
+      "PetitionUri=http://soe-%s.custhelp.com/app/answers/list/p/5833/c/5933",
+      "",
+      "[CommandQueue]",
+      "motd_uri=http://assets.daybreakgames.com/",
+      "",
+    ].join("\r\n");
+
+    const synchronized = synchronizeClientConfig(stock, runtime, localCreateSessionUrl);
+
+    expect(synchronized).not.toMatch(/h1z1\.com|daybreakgames\.com|custhelp\.com|platformpublishing\.com/i);
+    expect(synchronized.match(/^GameCrashUrl=/gim)).toHaveLength(1);
+    expect(synchronized.match(/^Address=/gim)).toHaveLength(1);
+    expect(synchronized.match(/^PetitionUri=/gim)).toHaveLength(1);
+    // The client appends the code digits right after "G", then "&info=".
+    expect(synchronized).toMatch(/^GameCrashUrl=https:\/\/rotk\.app\/game-error\?code=G$/m);
   });
 
   it("inserts root directives before the first INI section", () => {

--- a/tests/runtime-config.test.ts
+++ b/tests/runtime-config.test.ts
@@ -73,7 +73,10 @@ describe("public ROTK runtime", () => {
       "server=51.255.160.224:20042;51.255.160.224:20043;51.255.160.224:20044;51.255.160.224:20045",
     );
     expect(args).toContain("CommandQueue:motd_uri=http://51.255.160.224:8080/");
+    expect(args).toContain("WebResources:GameCrashUrl=https://test.rotk.app/game-error?code=G");
+    expect(args).toContain("Help:PetitionUri=https://test.rotk.app/support?locale=%s");
     expect(args.join(" ")).not.toContain("162.19.94.95");
+    expect(args.join(" ")).not.toContain("https://rotk.app");
   });
 
   it("passes only the short ticket and bounded GAME 2 endpoints to H1Z1", () => {
@@ -97,6 +100,11 @@ describe("public ROTK runtime", () => {
     );
     expect(args).toContain("VivoxGrantUrl=https://rotk.app");
     expect(args).toContain("CommandQueue:motd_uri=http://162.19.94.95:8080/");
+    // Nothing the client opens or uploads on its own may reach Daybreak.
+    expect(args).toContain("WebResources:GameCrashUrl=https://rotk.app/game-error?code=G");
+    expect(args).toContain("Help:PetitionUri=https://rotk.app/support?locale=%s");
+    expect(args).toContain("CrashReporter:Address=127.0.0.1:15081");
+    expect(args.join(" ")).not.toMatch(/h1z1\.com|daybreakgames\.com|custhelp\.com/i);
     expect(args.some((argument) => (
       argument.includes("162.19.94.95:8080/rest/auth/session/create")
     ))).toBe(false);


### PR DESCRIPTION
## Problème

`synchronizeClientConfig` réécrivait MOTD, EULA, télémétrie de lancement et service de ticket vers ROTK, mais laissait trois clés du `ClientConfig.ini` d'origine :

- `[WebResources] GameCrashUrl=https://www.donotannoythemwithtelemetry.com/king-of-the-kill/game-error?code=G` : le client y ajoute le code et `&info=…`, qui contient pour G9/G15 le ticket de session du joueur.
- `[Help] PetitionUri=http://donotannoythemwithsupport.custhelp.com/…`
- `[CrashReporter] Address=recap.donotannoythem.com:15081`

## Correctif

- `webEndpointDirectives(runtime)` : `GameCrashUrl=${websiteOrigin}/game-error?code=G`, `PetitionUri=${websiteOrigin}/support?locale=%s`, `Address=127.0.0.1:15081` (refus immédiat, aucune requête DNS).
- Appliqué à l'INI et aux arguments de lancement depuis la même liste.
- Les pages `/game-error` et `/support` sont livrées côté serveur (PR returnoftheking « route game-error, help, ticket and wallet endpoints to rotk.app »).

## Vérifications

- `npm run typecheck` vert.
- `vitest` : 196/197 verts ; le seul échec, `native-vivox-runtime.test.ts`, vient de l'absence de `resources/patches/vivoxsdk_x64.dll` (artefact `prepare:vivox`) dans un worktree frais, sans rapport avec ce changement.
- Nouveau test : un INI d'origine synchronisé ne contient plus aucun hôte h1z1.com / daybreakgames.com / custhelp.com / platformpublishing.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
