### PR TITLE
fix(assets): prepare native rank menu release

### DIFF
--- a/docs/asset-packs.md
+++ b/docs/asset-packs.md
@@ -2,6 +2,10 @@
 
 Issue: [#10](https://github.com/MzKaxD/rotk-launcher/issues/10)
 
+For the combined BR1315 rank menu, staff gate and settings update, use the
+[rank menu release recipe](rank-menu-assets.md). Its three packs must be published
+through the coordinated `.payload` archives and paired manifests described there.
+
 ## 1. Overview
 
 The launcher synchronizes custom ROTK assets from a dedicated GitHub repository

--- a/docs/rank-menu-assets.md
+++ b/docs/rank-menu-assets.md
@@ -1,0 +1,146 @@
+# BR1315 ranks: coordinated client asset release
+
+The server supplies seasonal ranks and native Top Ten data. A server tag alone
+does not repair the distributed menu: its old manager API and shadowing widget
+can leave Leaderboards blank. This release installs the compatible UIRoot and
+Top Ten widget in all three packs that can supply them. The kill-feed symbols
+already exist in the client and are selected by server packets.
+
+`npm run assets:prepare-ranks` packages a **reviewed, prebuilt candidate**; it is
+not an arbitrary GFX patcher. It pins the three installed pack sizes/SHA-256s,
+streams ZIP creation and complete decompression/readback, then writes both full
+manifests. Inputs are read-only and the output directory must not exist.
+No client assets are stored in this repository and no production publication
+happens when the command runs or this PR merges.
+
+## Relationship to the other PRs
+
+- [Launcher #38](https://github.com/MzKaxD/rotk-launcher/pull/38): the candidate
+  retains the native `IsModerator()` gate before opening the O-key admin panel,
+  with closing still available. This controls opening the UI; server permissions
+  continue to authorize admin actions.
+- [Launcher #39](https://github.com/MzKaxD/rotk-launcher/pull/39): the candidate
+  retains all four repaired PreGame settings panels. Its `ui_x64_2.pack2` is the
+  validated settings pack with only `TrialsTopTenWindow.gfx` replaced.
+- [Server #370](https://github.com/MzKaxD/returnoftheking/pull/370), merged as
+  `6cba76b5895cb70ca23e395d5846c2cb7f45e564`, supplies the data and reproducible
+  rank UI builder. Staff gating, the respawn guard and automatic region selection
+  are retained in the input root before the rank transform.
+
+The launcher PRs can be reviewed independently. For deployment, publish the
+combined packs once. Publishing #38's main pack or #39's settings-only pack
+afterward would remove rank UI changes. Their older standalone release candidates
+are not additional files to upload alongside this candidate.
+
+## Reconstruct the candidate from owned inputs
+
+Use Node 22.16.0 for pack transforms, Java 17 and FFDec 26.2.1. The server builder
+pins FFDec and the widget. Use the server revision above and #39's source revision
+`68f0bd755f0da3af3545379689df3d8b417684f3` for the settings recipe. All intermediate
+outputs must be separate staging files, never installed or hardlinked packs.
+
+1. Obtain the published main pack whose installed SHA-256 is
+   `b72dcc5245e654e498cadf5493761d63a93fea14904d3da32fda1545ae3d07f3`, and retail
+   `ui_x64_0.pack2` (`3a2c7f90b6c75ada48435a9e4499d6a5094f11a8d3d2ea903f690bbaf576d0db`)
+   and `ui_x64_2.pack2` (`bee6c209f89a8433e28b19bcf738cd0e99285bd21ae48c3258c4b99e048f60f0`).
+   These are operator-owned assets, not files supplied by the PR.
+2. Extract `UIRoot.gfx` from the published main pack using the server's
+   `devts/tools/pack2-workbench.mjs extract` command. Its SHA-256 must be
+   `cdd8d6925a6bfac73bb08335c1f221dc97214d31eee2cbcd4845b3f8cde4a769`.
+   Extract the modern `TrialsTopTenWindow.gfx` from retail `ui_x64_2.pack2`;
+   the builder requires SHA-256
+   `33a76a4e3336b07301e6fef23662c9df2ae3303cca4bf4c692812ed6946a9b21`.
+   When extracting, pass `--names names.json` with this minimal name map and
+   `--filter '^UIRoot[.]gfx$'` or `--filter '^TrialsTopTenWindow[.]gfx$'`, plus
+   a separate `--out` directory:
+
+   ```json
+   {"names":{"ef872dad597e632f":"UIRoot.gfx","ee63c2b5aa9adc28":"TrialsTopTenWindow.gfx"}}
+   ```
+3. From the server repository, run these transforms in order:
+
+   ```sh
+   node devts/tools/rotk-admin-host-panel-ui1315.mjs original/UIRoot.gfx stage/staff.gfx
+   node devts/tools/rotk-gameplay-ui1315.mjs stage/staff.gfx stage/gameplay.gfx
+   node devts/tools/rotk-auto-region-ui1315.mjs stage/gameplay.gfx stage/region.gfx
+   node devts/tools/build-rank-menu-client1315.mjs <java> <ffdec.jar> stage/region.gfx original/TrialsTopTenWindow.gfx stage/rank-gfx
+   ```
+
+4. Prepare the settings pack with #39's `assets:prepare-menu-settings` command
+   and the retail `ui_x64_2.pack2`. Use its generated pack only as an intermediate;
+   do not publish its standalone manifests. With Node 22.16.0 its SHA-256 is
+   `e44a94cd5d6807dcabc66a323fcee88789e8f479c14d823d1b5ddd613accef43`.
+5. Use the server's `pack2-workbench.mjs replace <source> --asset <name>
+   --file <GFX> --out <new-pack>` to assemble these outputs. Start from the inputs
+   in the table, not an earlier rank staging pack with accumulated edits:
+
+   | Final pack | Input | Replacements, in order |
+   | --- | --- | --- |
+   | `assets_x64_0.pack2` | Published main pack from step 1 | New `UIRoot.gfx`, then new `TrialsTopTenWindow.gfx`, through two separate output paths |
+   | `ui_x64_0.pack2` | Retail pack from step 1 | New `UIRoot.gfx` |
+   | `ui_x64_2.pack2` | Settings pack from step 4 | New `TrialsTopTenWindow.gfx` |
+
+   The replacement tool verifies every unaffected asset. Check all three final
+   pack hashes against `CANDIDATE` in `scripts/prepare-rank-menu-assets.mjs`.
+   Different inputs/tool output require review and revalidation, not bypassing
+   the hash checks.
+
+## Package and validate
+
+Put just the three final packs in a staging directory. Fetch the **current full**
+`feed.json` and `asset-payloads.v1.json` from `h1z1rotk/assets/main` before preparing
+the release. The checked baseline is assets-v1.6.0. Example version 1.7.0 is not
+reserved; choose a strictly higher version than the current feed.
+
+```sh
+npm ci
+npm run assets:prepare-ranks -- <packs-directory> <current-feed.json> <current-payloads.json> <new-output-directory> 1.7.0
+npm run test:assets:ranks
+```
+
+The output is `assets_x64_0.payload`, `rank_menu_ui.payload`, `feed.json`,
+`asset-payloads.v1.json` and `verification.json`. Both `.payload` files are ZIP
+containers. Keep their suffix: a conventional `.zip` name is automatically
+discovered by the launcher and could activate one pack before the other two.
+The main archive contains one pack; the UI archive contains the other two.
+Unrelated catalog rows, versions, URLs and hashes remain unchanged.
+
+The tool refuses a changed main pack, existing UI-pack ownership, inconsistent
+manifests or a non-increasing version. If #38, #39 or another UI release has already
+shipped, reconcile that published release and regenerate/revalidate the candidate
+first. Do not overwrite its catalog with a saved v1.6.0 copy.
+
+For an offline test using the actual generated archives, set
+`ROTK_RANK_RELEASE_PROOF` to their output directory and run
+`npm run test:assets:ranks`. It exercises the production `AssetSyncService` in
+an isolated temporary client, with local HTTP responses: three installed hashes,
+repeat sync without downloads, same-size corruption repair from verified cache,
+and restoration of synthetic originals. It does not modify a real installation.
+Allow approximately 7 GB of temporary space for this test.
+
+## Maintainer deployment
+
+1. Deploy server #370 with its normal PostgreSQL configuration in menu and Solo
+   roles, role-boundary grants and an active published season including public
+   Solo games. Existing eligible results count; fewer than ten means unranked.
+2. Upload both `.payload` attachments to the chosen `assets-vX.Y.Z` release in
+   `h1z1rotk/assets`. Publish the matching full feed and payload manifests in the
+   same assets-repository commit. Uploading attachments alone leaves the old
+   per-asset catalog active.
+3. Coordinate the effective feed with the server's normal attestation-policy
+   publisher, including installed launcher DLLs. Do not change the signed retail
+   base manifest or relax integrity enforcement to accept mismatched packs.
+4. Synchronize/restart a fresh client. Verify Leaderboards, qualification/Top Ten,
+   the current rank, settings pages, O-key staff gating and a public Solo badge.
+   No new launcher executable or OVH port is required by this asset update.
+
+Native rank validation used isolated Teuf Admin fixtures: 0/9/10 results,
+Royalty V, live refresh and 10-kill row decoration. It did not import fixtures into
+production or simulate a completed live two-player ranked match. The native widget
+shows current rank and 10/20-kill backgrounds; obsolete rewards are hidden.
+End-match promotion animations are outside server #370.
+
+For rollback, restore the prior **paired** feed/payload manifests and matching
+integrity policy, retain the old attachments, and verify client synchronization.
+Do not combine old root/UI packs with the new widget. Launcher's Restore function
+is also covered by the isolated installer test.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "verify:vivox-runtime": "node scripts/verify-vivox-runtime.mjs",
     "build:diagnostics": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-diagnostics.ps1",
     "test:native:diagnostics": "node --test native/diagnostics/tests/integration.mjs",
-    "verify:presentmon": "node scripts/verify-presentmon.mjs"
+    "verify:presentmon": "node scripts/verify-presentmon.mjs",
+    "pretest": "npm run test:assets:ranks",
+    "test:assets:ranks": "node --test scripts/tests/rank-menu-assets.test.mjs",
+    "assets:prepare-ranks": "node scripts/prepare-rank-menu-assets.mjs"
   },
   "dependencies": {
     "@fontsource/barlow-condensed": "^5.2.8",

--- a/scripts/prepare-rank-menu-assets.mjs
+++ b/scripts/prepare-rank-menu-assets.mjs
@@ -1,0 +1,190 @@
+/** Package the reviewed BR1315 rank/menu candidate. Offline; no installation writes. */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { fileURLToPath } from "node:url";
+import yazl from "yazl";
+import yauzl from "yauzl";
+
+export const SOURCE_PACK_SHA256 = "b72dcc5245e654e498cadf5493761d63a93fea14904d3da32fda1545ae3d07f3";
+export const CANDIDATE = Object.freeze({
+  "assets_x64_0.pack2": { size: 2479583592, sha256: "16ffa81000fde4e9b3c39b536630831132a1fe3bc47d24e560e29ca52d080aa8" },
+  "ui_x64_0.pack2": { size: 48635677, sha256: "6b49db5f80c24a2eed253c34c29db0a8131fc3a4935a8150f7532f801f8c28d7" },
+  "ui_x64_2.pack2": { size: 48664842, sha256: "98890f61762f39d6e860eb5928498573ac22cf1c36eb6c99fe5fe9f6e35518b3" },
+});
+const groups = {
+  assets_x64_0: ["assets_x64_0.pack2"],
+  rank_menu_ui: ["ui_x64_0.pack2", "ui_x64_2.pack2"],
+};
+const installPath = "Resources/Assets";
+const mainTarget = `${installPath}/assets_x64_0.pack2`;
+const hash = () => createHash("sha256");
+export async function metadata(file) {
+  const digest = hash();
+  let size = 0;
+  for await (const chunk of fs.createReadStream(file)) { size += chunk.length; digest.update(chunk); }
+  return { size, sha256: digest.digest("hex") };
+}
+const pathKey = value => {
+  assert.equal(typeof value, "string", "invalid manifest path");
+  const normalized = value.replaceAll("\\", "/");
+  assert(normalized.length > 0 && !/[:\x00-\x1f]/.test(normalized)
+    && normalized.split("/").every(part => part && part !== "." && part !== ".."), "unsafe manifest path");
+  return normalized.toLowerCase();
+};
+const nameKey = value => {
+  assert.equal(typeof value, "string", "invalid asset name");
+  assert.match(value, /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/);
+  return value.toLowerCase();
+};
+function validMetadata(row, limit = 3 * 1024 ** 3) {
+  assert(row && Number.isSafeInteger(row.size) && row.size > 0 && row.size <= limit, "invalid file size");
+  assert.match(row.sha256, /^[a-f0-9]{64}$/, "invalid file SHA-256");
+}
+function versionParts(value) {
+  assert.match(value, /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/, "expected X.Y.Z version");
+  return value.split(".").map(BigInt);
+}
+
+/** Preserve the full catalog, refuse replacing a newer/conflicting UI release. */
+export function updateManifests(feed, payloads, version, archives, packs) {
+  assert.equal(feed.manifestVersion, 1);
+  assert.equal(payloads.schemaVersion, 1);
+  assert.equal(payloads.kind, "asset-payloads");
+  assert.equal(feed.packVersion, payloads.packVersion, "base manifests disagree");
+  const old = versionParts(feed.packVersion), next = versionParts(version);
+  assert(next.map((v, i) => v - old[i]).find(v => v !== 0n) > 0n, "release version must increase");
+  assert(Array.isArray(feed.assets) && feed.assets.length > 0 && feed.assets.length < 64);
+  assert(Array.isArray(payloads.files) && payloads.files.length > 0 && payloads.files.length < 20_000);
+  const assets = new Map();
+  for (const asset of feed.assets) {
+    const key = nameKey(asset.name);
+    assert(!assets.has(key), "duplicate asset");
+    assert(asset.type === "zip" || asset.type === "file", "invalid asset type");
+    pathKey(asset.installPath);
+    validMetadata(asset, 2 * 1024 ** 3 - 1);
+    assets.set(key, asset);
+  }
+  const paths = new Set(), owned = new Set();
+  for (const row of payloads.files) {
+    validMetadata(row);
+    const key = pathKey(row.path), owner = nameKey(row.asset), asset = assets.get(owner);
+    assert(!paths.has(key), "duplicate payload path");
+    assert(asset, "unknown payload owner");
+    const root = pathKey(asset.installPath);
+    assert(asset.type === "zip" ? key.startsWith(root + "/") : key === root, "payload outside asset install path");
+    paths.add(key); owned.add(owner);
+  }
+  assert([...assets.keys()].every(key => owned.has(key)), "asset missing payload metadata");
+  assert(!assets.has("rank_menu_ui") && !assets.has("ui_x64_0") && !assets.has("ui_x64_2"),
+    "base catalog already owns a UI update; reconcile that release first");
+  for (const name of groups.rank_menu_ui) assert(!paths.has(pathKey(`${installPath}/${name}`)),
+    "base catalog already owns a UI pack; reconcile that release first");
+  const main = assets.get("assets_x64_0");
+  assert(main?.type === "zip" && pathKey(main.installPath) === pathKey(installPath), "unsupported main pack entry");
+  const sourceRows = payloads.files.filter(row => nameKey(row.asset) === "assets_x64_0");
+  assert(sourceRows.length === 1 && pathKey(sourceRows[0].path) === pathKey(mainTarget), "unsupported main pack ownership");
+  assert.equal(sourceRows[0].sha256, SOURCE_PACK_SHA256, "main pack changed; reconcile that release first");
+  assert.equal(sourceRows[0].size, 2479085469, "unexpected source pack size");
+  for (const name of Object.keys(CANDIDATE)) validMetadata(packs[name]);
+  const changed = Object.entries(groups).map(([name]) => {
+    validMetadata(archives[name], 2 * 1024 ** 3 - 1);
+    return { ...(name === "assets_x64_0" ? main : {}), name, version, type: "zip", installPath,
+      // Both remain feed-driven: never expose half a three-pack update through
+      // the launcher's automatic <pack>.zip discovery in releases/latest.
+      url: `https://github.com/h1z1rotk/assets/releases/download/assets-v${version}/${name}.payload`,
+      ...archives[name] };
+  });
+  const files = payloads.files.filter(row => nameKey(row.asset) !== "assets_x64_0");
+  for (const [asset, names] of Object.entries(groups)) for (const name of names) {
+    files.push({ asset, path: `${installPath}/${name}`, ...packs[name] });
+  }
+  assert(files.length <= 20_000, "launcher payload count exceeded");
+  assert(files.reduce((sum, row) => sum + row.size, 0) <= 8 * 1024 ** 3, "launcher payload limit exceeded");
+  return {
+    feed: { ...feed, packVersion: version, assets: feed.assets.map(asset => nameKey(asset.name) === "assets_x64_0" ? changed[0] : asset).concat(changed[1]) },
+    payloads: { ...payloads, packVersion: version, files },
+  };
+}
+
+export async function writeArchive(directory, names, output) {
+  const zip = new yazl.ZipFile();
+  for (const name of names) {
+    assert(Object.hasOwn(CANDIDATE, name), "unsupported archive entry");
+    zip.addFile(path.join(directory, name), name, { mtime: new Date("2020-01-01T00:00:00Z"), mode: 0o100644, compressionLevel: 6 });
+  }
+  const completed = pipeline(zip.outputStream, fs.createWriteStream(output, { flags: "wx" }));
+  zip.end({ forceZip64Format: false });
+  await completed;
+}
+
+/** Stream every decompressed byte back; detects input changes during packaging. */
+export async function verifyArchive(file, expected) {
+  const zip = await new Promise((resolve, reject) => yauzl.open(file, { lazyEntries: true }, (error, value) => error ? reject(error) : resolve(value)));
+  return new Promise((resolve, reject) => {
+    const found = new Set();
+    const fail = error => { zip.close(); reject(error); };
+    zip.on("error", fail);
+    zip.on("end", () => {
+      try { assert.equal(found.size, Object.keys(expected).length, "missing archive entry"); resolve(); }
+      catch (error) { fail(error); }
+    });
+    zip.on("entry", entry => {
+      (async () => {
+        assert(Object.hasOwn(expected, entry.fileName) && !found.has(entry.fileName), "unexpected archive entry");
+        found.add(entry.fileName);
+        const want = expected[entry.fileName];
+        assert.equal(entry.uncompressedSize, want.size, "archive size mismatch");
+        const stream = await new Promise((res, rej) => zip.openReadStream(entry, (error, value) => error ? rej(error) : res(value)));
+        const digest = hash(); let size = 0;
+        for await (const chunk of stream) { size += chunk.length; assert(size <= want.size); digest.update(chunk); }
+        assert.equal(size, want.size);
+        assert.equal(digest.digest("hex"), want.sha256, "archive payload SHA-256 mismatch");
+        zip.readEntry();
+      })().catch(fail);
+    });
+    zip.readEntry();
+  });
+}
+
+export async function prepareRelease({ directory, feedPath, payloadPath, output, version }) {
+  const packs = {};
+  for (const [name, expected] of Object.entries(CANDIDATE)) {
+    const file = path.join(directory, name);
+    assert.equal(fs.statSync(file).size, expected.size, `unsupported candidate size: ${name}`);
+    packs[name] = await metadata(file);
+    assert.deepEqual(packs[name], expected, `unsupported candidate: ${name}`);
+  }
+  const json = file => JSON.parse(fs.readFileSync(file, "utf8").replace(/^\uFEFF/, ""));
+  const feed = json(feedPath), payloads = json(payloadPath);
+  const placeholder = { size: 1, sha256: "0".repeat(64) };
+  updateManifests(feed, payloads, version, { assets_x64_0: placeholder, rank_menu_ui: placeholder }, packs);
+  fs.mkdirSync(output); // Exclusive; never overwrite a client or another staging run.
+  const archives = {};
+  for (const [asset, names] of Object.entries(groups)) {
+    const archive = path.join(output, `${asset}.payload`);
+    await writeArchive(directory, names, `${archive}.partial`);
+    await verifyArchive(`${archive}.partial`, Object.fromEntries(names.map(name => [name, packs[name]])));
+    fs.renameSync(`${archive}.partial`, archive);
+    archives[asset] = await metadata(archive);
+  }
+  const next = updateManifests(feed, payloads, version, archives, packs);
+  const report = { packVersion: version, packs, archives, verifiedArchivePayloads: true, published: false };
+  for (const [name, data] of [["feed.json", next.feed], ["asset-payloads.v1.json", next.payloads], ["verification.json", report]]) {
+    fs.writeFileSync(path.join(output, name), JSON.stringify(data, null, 2) + "\n", { flag: "wx" });
+  }
+  return report;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [directory, feedPath, payloadPath, output, version, ...extra] = process.argv.slice(2);
+  if (![directory, feedPath, payloadPath, output, version].every(Boolean) || extra.length) {
+    console.error("Usage: node scripts/prepare-rank-menu-assets.mjs <reviewed-packs-directory> <current-feed.json> <current-payloads.json> <new-output-directory> <X.Y.Z>");
+    process.exitCode = 2;
+  } else {
+    prepareRelease({ directory, feedPath, payloadPath, output, version }).then(report => console.log(JSON.stringify(report, null, 2)))
+      .catch(error => { console.error(error.message); process.exitCode = 1; });
+  }
+}

--- a/scripts/tests/rank-menu-assets.test.mjs
+++ b/scripts/tests/rank-menu-assets.test.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { buildSync } from "esbuild";
+import { CANDIDATE, SOURCE_PACK_SHA256, metadata, prepareRelease, updateManifests,
+  verifyArchive, writeArchive } from "../prepare-rank-menu-assets.mjs";
+
+const names = Object.keys(CANDIDATE);
+const info = bytes => ({ size: bytes.length, sha256: createHash("sha256").update(bytes).digest("hex") });
+const small = info(Buffer.from("synthetic placeholder"));
+const archives = { assets_x64_0: small, rank_menu_ui: small };
+const packs = Object.fromEntries(names.map(name => [name, small]));
+function baseline() {
+  const assets = ["assets_x64_0", "unchanged"].map(name => ({ name, version: "1.6.0", type: "zip",
+    installPath: "Resources/Assets", url: `https://github.com/h1z1rotk/assets/releases/download/assets-v1.6.0/${name}.zip`, ...small }));
+  return {
+    feed: { manifestVersion: 1, packVersion: "1.6.0", assets },
+    payloads: { schemaVersion: 1, kind: "asset-payloads", packVersion: "1.6.0", files: [
+      { asset: "assets_x64_0", path: "Resources/Assets/assets_x64_0.pack2", size: 2479085469, sha256: SOURCE_PACK_SHA256 },
+      { asset: "unchanged", path: "Resources/Assets/unchanged.pack2", ...small },
+    ] },
+  };
+}
+const update = (base = baseline(), version = "1.7.0", a = archives, p = packs) =>
+  updateManifests(base.feed, base.payloads, version, a, p);
+function temporary(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rotk-rank-release-"));
+  t.after(() => {
+    assert(path.dirname(dir) === path.resolve(os.tmpdir()) && path.basename(dir).startsWith("rotk-rank-release-"));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+  return dir;
+}
+
+test("coordinated manifests preserve the existing catalog and assign both UI packs to one archive", () => {
+  const base = baseline(), before = structuredClone(base), next = update(base);
+  assert.deepEqual(base, before);
+  assert.deepEqual(next.feed.assets[1], base.feed.assets[1]);
+  assert.deepEqual(next.payloads.files[0], base.payloads.files[1]);
+  assert.equal(next.feed.packVersion, next.payloads.packVersion);
+  assert.equal(next.feed.assets.length, 3);
+  assert.deepEqual(next.payloads.files.filter(f => f.asset === "rank_menu_ui").map(f => f.path),
+    ["Resources/Assets/ui_x64_0.pack2", "Resources/Assets/ui_x64_2.pack2"]);
+  for (const entry of [next.feed.assets[0], next.feed.assets[2]]) assert(entry.url.endsWith(`${entry.name}.payload`));
+});
+
+test("refuses stale, published admin/settings or overlapping releases instead of overwriting fixes", () => {
+  for (const version of ["1.6.0", "1.5.9", "01.7.0", "1.7.0-rc"]) assert.throws(() => update(baseline(), version));
+  const changed = baseline(); changed.payloads.files[0].sha256 = "0".repeat(64);
+  assert.throws(() => update(changed), /main pack changed/);
+  const mismatch = baseline(); mismatch.payloads.packVersion = "1.5.0";
+  assert.throws(() => update(mismatch), /disagree/);
+  const settings = baseline();
+  settings.feed.assets.push({ ...settings.feed.assets[1], name: "UI_X64_2" });
+  settings.payloads.files.push({ asset: "UI_X64_2", path: "Resources/Assets/UI_X64_2.pack2", ...small });
+  assert.throws(() => update(settings), /already owns/);
+  const alias = baseline(); alias.payloads.files.push({ asset: "unchanged", path: "resources\\assets\\UI_X64_0.pack2", ...small });
+  assert.throws(() => update(alias), /already owns/);
+  assert.throws(() => update(update(), "1.8.0"), /already owns/);
+});
+
+test("refuses invalid ownership, unsafe paths, duplicate payloads and oversized releases", () => {
+  const duplicate = baseline(); duplicate.payloads.files.push({ ...duplicate.payloads.files[0], path: "resources\\assets\\ASSETS_X64_0.pack2" });
+  assert.throws(() => update(duplicate), /duplicate payload/);
+  const missing = baseline(); missing.payloads.files.pop();
+  assert.throws(() => update(missing), /missing payload/);
+  const unknown = baseline(); unknown.payloads.files[1].asset = "missing";
+  assert.throws(() => update(unknown), /unknown payload owner/);
+  for (const target of ["../outside", "C:/outside", "Resources/Assets/../x", "Elsewhere/x"]) {
+    const bad = baseline(); bad.payloads.files[1].path = target;
+    assert.throws(() => update(bad), /unsafe|outside/);
+  }
+  assert.throws(() => update(baseline(), "1.7.0", { ...archives, rank_menu_ui: { ...small, size: 2 * 1024 ** 3 } }), /size/);
+  assert.throws(() => update(baseline(), "1.7.0", archives, Object.fromEntries(names.map(n => [n, { ...small, size: 3 * 1024 ** 3 }]))), /payload limit/);
+});
+
+test("production preparation rejects unreviewed packs before creating output or changing inputs", async t => {
+  const dir = temporary(t), output = path.join(dir, "output");
+  for (const name of names) fs.writeFileSync(path.join(dir, name), name);
+  await assert.rejects(prepareRelease({ directory: dir, output }), /unsupported candidate size/);
+  assert(!fs.existsSync(output));
+  for (const name of names) assert.equal(fs.readFileSync(path.join(dir, name), "utf8"), name);
+});
+
+test("archive readback verifies every decompressed name, size and SHA-256", async t => {
+  const dir = temporary(t), expected = {};
+  for (const name of names) {
+    fs.writeFileSync(path.join(dir, name), Buffer.from(`invented pack: ${name}`));
+    expected[name] = await metadata(path.join(dir, name));
+  }
+  const archive = path.join(dir, "test.payload");
+  await writeArchive(dir, names, archive);
+  await verifyArchive(archive, expected);
+  await assert.rejects(verifyArchive(archive, { ...expected, "missing.pack2": small }), /missing archive/);
+  await assert.rejects(verifyArchive(archive, { [names[0]]: expected[names[0]] }), /unexpected archive/);
+  await assert.rejects(verifyArchive(archive, { ...expected, [names[0]]: { ...expected[names[0]], sha256: "0".repeat(64) } }), /SHA-256/);
+  await assert.rejects(writeArchive(dir, names, archive), /EEXIST/);
+});
+
+test("real launcher installs all three packs, skips repeat sync, repairs corruption, restores originals", async t => {
+  const dir = temporary(t), project = fileURLToPath(new URL("../../", import.meta.url));
+  const stub = path.join(dir, "electron.mjs"), bundle = path.join(dir, "asset-sync.cjs");
+  fs.writeFileSync(stub, "export const app = new Proxy({}, {get(){throw Error('Unexpected Electron UI access')}});");
+  buildSync({ entryPoints: [path.join(project, "electron/services/asset-sync.ts")], outfile: bundle,
+    bundle: true, platform: "node", format: "cjs", alias: { electron: stub } });
+  const { AssetSyncService, ASSET_FEED_URL, ASSET_RELEASE_API_URL, parseAssetManifest, mergeGitHubReleaseAssets } = createRequire(import.meta.url)(bundle);
+  const realRelease = process.env.ROTK_RANK_RELEASE_PROOF;
+  let candidate, archiveDir;
+  if (realRelease) {
+    archiveDir = path.resolve(realRelease);
+    candidate = { feed: JSON.parse(fs.readFileSync(path.join(archiveDir, "feed.json"))),
+      payloads: JSON.parse(fs.readFileSync(path.join(archiveDir, "asset-payloads.v1.json"))) };
+    for (const name of names) assert.deepEqual(
+      (({ size, sha256 }) => ({ size, sha256 }))(candidate.payloads.files.find(row => row.path === `Resources/Assets/${name}`)), CANDIDATE[name]);
+  } else {
+    archiveDir = dir;
+    const p = {};
+    for (const name of names) { fs.writeFileSync(path.join(dir, name), `synthetic updated ${name}`); p[name] = await metadata(path.join(dir, name)); }
+    await writeArchive(dir, [names[0]], path.join(dir, "assets_x64_0.payload"));
+    await writeArchive(dir, names.slice(1), path.join(dir, "rank_menu_ui.payload"));
+    const a = {};
+    for (const asset of Object.keys(archives)) a[asset] = await metadata(path.join(dir, `${asset}.payload`));
+    candidate = update(baseline(), "1.7.0", a, p);
+  }
+  const changed = candidate.feed.assets.filter(a => Object.hasOwn(archives, a.name));
+  const release = { tag_name: `assets-v${candidate.feed.packVersion}`, draft: false, prerelease: false,
+    assets: changed.map(a => ({ name: `${a.name}.payload`, browser_download_url: a.url, size: a.size, digest: `sha256:${a.sha256}` })) };
+  assert.deepEqual(mergeGitHubReleaseAssets(parseAssetManifest(baseline().feed), release).assets, parseAssetManifest(baseline().feed).assets,
+    "publishing archives first must leave the old catalog active");
+  assert.deepEqual(mergeGitHubReleaseAssets(parseAssetManifest(candidate.feed), release), parseAssetManifest(candidate.feed));
+  const client = path.join(dir, "client"), assets = path.join(client, "Resources/Assets");
+  fs.mkdirSync(assets, { recursive: true }); fs.writeFileSync(path.join(client, ".rotk-installation.json"), "{}");
+  const originals = Object.fromEntries(names.map(name => [name, Buffer.from(`synthetic original ${name}`)]));
+  for (const [name, bytes] of Object.entries(originals)) fs.writeFileSync(path.join(assets, name), bytes);
+  let downloads = 0;
+  const sync = new AssetSyncService({ userDataDirectory: path.join(dir, "userdata"), fetchImpl: async input => {
+    const url = String(input);
+    if (url === ASSET_FEED_URL) return Response.json({ ...candidate.feed, assets: changed });
+    if (url === ASSET_RELEASE_API_URL) return Response.json(release);
+    const asset = changed.find(a => a.url === url);
+    assert(asset, "unexpected network request"); downloads++;
+    return new Response(Readable.toWeb(fs.createReadStream(path.join(archiveDir, `${asset.name}.payload`))));
+  } });
+  const checkPacks = async () => {
+    for (const name of names) {
+      const row = candidate.payloads.files.find(f => f.path === `Resources/Assets/${name}`);
+      assert.deepEqual(await metadata(path.join(assets, name)), { size: row.size, sha256: row.sha256 });
+    }
+  };
+  assert.equal((await sync.sync(client)).status, "updated"); await checkPacks();
+  assert.equal(downloads, 2);
+  assert.equal((await sync.sync(client)).status, "up-to-date");
+  for (const name of names) {
+    const file = fs.openSync(path.join(assets, name), "r+");
+    try { fs.writeSync(file, Buffer.from([0xff]), 0, 1, 0); } finally { fs.closeSync(file); }
+  }
+  assert.equal((await sync.verify(client)).status, "updated"); await checkPacks();
+  assert.equal(downloads, 2, "corruption repair reuses both verified archive caches");
+  await sync.restore(client);
+  for (const name of names) assert(fs.readFileSync(path.join(assets, name)).equals(originals[name]));
+  assert.equal(await sync.readState(), null);
+});


### PR DESCRIPTION
After server #370, players can receive seasonal kill-feed badges while Leaderboards still opens the old blank client menu. This prepares the three client packs needed for the native Top Ten screen through the existing asset channel; no launcher executable change is required.

Adds `npm run assets:prepare-ranks` for the reviewed combined candidate. It pins installed pack sizes/SHA-256s, streams two ZIP-format `.payload` archives, verifies every decompressed name/size/hash, and writes coordinated full feed/payload manifests while preserving unrelated catalog entries. It refuses stale/conflicting main or UI releases and never edits an installation or publishes anything. Both archive suffixes avoid automatic ZIP discovery activating one pack before the other two.

The candidate preserves the O-key native staff gate from #38, all four settings-page fixes from #39, the respawn guard and automatic region selection. The rank builder restores the missing manager API, installs matching widget copies and fixes 10/20-kill row decoration. The documentation gives the pinned source revisions, owned input hashes, reconstruction steps, rollout and rollback. No proprietary client assets are committed.

Validation:
- Windows / Node 22.16.0 / Zig 0.15.2: `npm run prepare:vivox` and `npm run build` passed, including typechecks, six new packaging/integration tests, 18 native diagnostic tests, crouch checks and 320 Vitest tests (three skipped).
- Reconstructed the candidate from the published main pack, retail UI packs and #39's settings recipe. Generated UIRoot and Top Ten GFX are byte-identical to the native-tested files. The final root retains `IsModerator()` before opening the admin panel; only the Top Ten entry differs from the validated settings pack.
- Prepared both actual archives with Node 22 and verified all decompressed payloads. The real launcher installed all three full-size packs in an isolated client directory, skipped repeat downloads, repaired same-size corruption from cache and restored the synthetic originals. HTTP responses were supplied locally; production was untouched.
- Native Teuf Admin harness previously verified 0/9/10 isolated results, Royalty V, live refresh and the 10-kill background. This is fixture validation, not production account data or a completed live two-player match.
- The public full feed/payload baseline was checked again and remains assets-v1.6.0. Candidate version 1.7.0 is a local proposal, not a reservation or published release.

**Maintainer action after review:** deploy merged [server #370](https://github.com/MzKaxD/returnoftheking/pull/370), then publish the two generated attachments and paired manifests to `h1z1rotk/assets`, coordinated with the existing server integrity policy. Merging this launcher PR alone does not distribute the menu. See [the release recipe](https://github.com/Teufzer/rotk-launcher/blob/9bd764b15187e7af1f1bf3374f71eae4f20ac914/docs/rank-menu-assets.md).

This targets main independently of #38 and #39. Review their code normally, but publish the combined candidate once; publishing either older standalone UI candidate afterward would remove rank changes. If another affected asset release ships first, reconcile/revalidate against its live catalog instead of overwriting it.

GitHub CI: [run 34728742595](https://github.com/MzKaxD/rotk-launcher/actions/runs/34728742595) reports `action_required`; a repository maintainer must authorize this fork workflow before remote checks can run. The successful checks above were performed locally.